### PR TITLE
feat: add reserves list command to CLI

### DIFF
--- a/.changeset/bumpy-plants-guess.md
+++ b/.changeset/bumpy-plants-guess.md
@@ -1,0 +1,5 @@
+---
+"@aave/cli": patch
+---
+
+**feat:** add reserves list command to CLI

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,6 +30,7 @@ USAGE
 # Commands
 <!-- commands -->
 * [`aave hubs list`](#aave-hubs-list)
+* [`aave reserves list`](#aave-reserves-list)
 * [`aave spokes list`](#aave-spokes-list)
 
 ## `aave hubs list`
@@ -51,6 +52,31 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/hubs/list.ts](https://github.com/aave/aave-v4-sdk/blob/v4.1.0-next.3/src/commands/hubs/list.ts)_
+
+## `aave reserves list`
+
+List Aave v4 reserves
+
+```
+USAGE
+  $ aave reserves list [-s <spoke-id>] [-h <hub-id>] [--hub_address <evm-address> -c <chain-id>]
+
+FLAGS
+  -c, --chain_id=<chain-id>        The chain ID (e.g. 1, 137, 42161)
+  -h, --hub_id=<hub-id>            The hub ID (e.g. SGVsbG8h…)
+  -s, --spoke_id=<spoke-id>        The spoke ID (e.g. SGVsbG8h…)
+      --hub_address=<evm-address>  The hub address (e.g. 0x123…)
+
+DESCRIPTION
+  List Aave v4 reserves
+
+EXAMPLES
+  $ aave reserves list --spoke_id MTIzNDU2Nzg5OjoweEJh...
+  $ aave reserves list --hub_id MTIzNDU2Nzg5OjoweGFEOTA1...
+  $ aave reserves list --chain_id 123456789
+```
+
+_See code: [src/commands/reserves/list.ts](https://github.com/aave/aave-v4-sdk/blob/v4.0.0/src/commands/reserves/list.ts)_
 
 ## `aave spokes list`
 

--- a/packages/cli/src/commands/reserves/list.ts
+++ b/packages/cli/src/commands/reserves/list.ts
@@ -1,0 +1,103 @@
+import {
+  InvariantError,
+  ok,
+  ResultAsync,
+  type Reserve,
+  type ReservesRequest,
+  type UnexpectedError,
+  spokeId,
+  type SpokeId,
+} from '@aave/client';
+import { reserves } from '@aave/client/actions';
+
+import * as common from '../../common.js';
+
+export default class ListReserves extends common.V4Command {
+  static override description = 'List Aave v4 reserves';
+
+  static override flags = {
+    spoke_id: common.spoke(),
+    // TODO: Add more flexible query options later:
+    // hub_id: common.hub(),
+    // chain_id: common.chain(),
+    // hub_address: common.address(),
+  };
+
+  protected override headers = [
+    { value: 'Asset' },
+    { value: 'Symbol' },
+    { value: 'Spoke' },
+    { value: 'Chain' },
+    { value: 'Supply APY' },
+    { value: 'Borrow APY' },
+    { value: 'ID' },
+    // TODO: You can add more columns from Reserve type:
+    // - Available Liquidity: item.summary.supplied.amount (or formatted)
+    // - Borrowed: item.summary.borrowed.amount
+    // - Can Borrow: item.canBorrow
+    // - Can Supply: item.canSupply
+  ];
+
+  private getReservesRequest(): ResultAsync<
+    ReservesRequest,
+    InvariantError | UnexpectedError
+  > {
+    return ResultAsync.fromPromise(
+      this.parse(ListReserves),
+      (error) => new InvariantError(String(error)),
+    ).andThen(({ flags }) => {
+      if (!flags.spoke_id) {
+        return ResultAsync.fromSafePromise(
+          Promise.reject(new InvariantError('--spoke_id is required')),
+        );
+      }
+      
+      return ok({
+        query: { spokeId: flags.spoke_id },
+      });
+
+      // TODO: Add more flexible query options later:
+      // if (flags.hub_id) {
+      //   return ok({ query: { hubId: flags.hub_id } });
+      // }
+      // if (flags.chain_id) {
+      //   return ok({ query: { chainIds: [flags.chain_id] } });
+      // }
+      // if (flags.hub_address && flags.chain_id) {
+      //   return ok({
+      //     query: {
+      //       hub: {
+      //         address: flags.hub_address,
+      //         chainId: flags.chain_id,
+      //       },
+      //     },
+      //   });
+      // }
+    });
+  }
+
+  async run(): Promise<Reserve[]> {
+    const result = await this.getReservesRequest().andThen((request) =>
+      reserves(this.client, request),
+    );
+
+    if (result.isErr()) {
+      this.error(result.error);
+    }
+
+    // Format the output - map each reserve to an array of column values
+    this.display(
+      result.value.map((item) => [
+        item.asset.underlying.info.name,
+        item.asset.underlying.info.symbol,
+        item.spoke.name,
+        `${item.chain.name} (${item.chain.chainId})`,
+        `${item.summary.supplyApy.normalized}%`,
+        `${item.summary.borrowApy.normalized}%`,
+        item.id,
+      ]),
+    );
+
+    return result.value;
+  }
+}

--- a/packages/cli/src/commands/reserves/list.ts
+++ b/packages/cli/src/commands/reserves/list.ts
@@ -2,19 +2,18 @@ import {
   InvariantError,
   invariant,
   ok,
-  ResultAsync,
+  type PercentNumber,
   type Reserve,
   type ReservesRequest,
+  ResultAsync,
   type UnexpectedError,
 } from '@aave/client';
 import { reserves } from '@aave/client/actions';
 
 import * as common from '../../common.js';
 
-
-
-function formatApy(apy: { normalized: unknown }, decimals = 4): string {
-  return `${parseFloat(String(apy.normalized)).toFixed(decimals)}%`;
+function formatApy(apy: PercentNumber, decimals = 4): string {
+  return `${apy.normalized.toFixed(decimals)}%`;
 }
 
 export default class ListReserves extends common.V4Command {
@@ -133,7 +132,6 @@ export default class ListReserves extends common.V4Command {
       this.error(result.error);
     }
 
-    
     this.display(
       result.value.map((item) => [
         item.asset.underlying.info.name,
@@ -142,8 +140,8 @@ export default class ListReserves extends common.V4Command {
         `${item.chain.name} (${item.chain.chainId})`,
         formatApy(item.summary.supplyApy),
         formatApy(item.summary.borrowApy),
-        `$${item.summary.supplied.fiatAmount.value}`,
-        `$${item.summary.borrowed.fiatAmount.value}`,
+        `${item.summary.supplied.exchange.symbol}${item.summary.supplied.exchange.value.toFixed(2)}`,
+        `${item.summary.borrowed.exchange.symbol}${item.summary.borrowed.exchange.value.toFixed(2)}`,
         item.canSupply ? 'Yes' : 'No',
         item.canBorrow ? 'Yes' : 'No',
         item.canUseAsCollateral ? 'Yes' : 'No',

--- a/packages/cli/src/commands/reserves/list.ts
+++ b/packages/cli/src/commands/reserves/list.ts
@@ -11,6 +11,12 @@ import { reserves } from '@aave/client/actions';
 
 import * as common from '../../common.js';
 
+
+
+function formatApy(apy: { normalized: unknown }, decimals = 4): string {
+  return `${parseFloat(String(apy.normalized)).toFixed(decimals)}%`;
+}
+
 export default class ListReserves extends common.V4Command {
   static override description = 'List Aave v4 reserves';
 
@@ -66,12 +72,12 @@ export default class ListReserves extends common.V4Command {
     { value: 'Chain' },
     { value: 'Supply APY' },
     { value: 'Borrow APY' },
+    { value: 'Available Liquidity' },
+    { value: 'Total Borrowed' },
+    { value: 'Can Supply' },
+    { value: 'Can Borrow' },
+    { value: 'Collateral' },
     { value: 'ID' },
-    // TODO: You can add more columns from Reserve type:
-    // - Available Liquidity: item.summary.supplied.amount (or formatted)
-    // - Borrowed: item.summary.borrowed.amount
-    // - Can Borrow: item.canBorrow
-    // - Can Supply: item.canSupply
   ];
 
   private getReservesRequest(): ResultAsync<
@@ -127,15 +133,20 @@ export default class ListReserves extends common.V4Command {
       this.error(result.error);
     }
 
-    // Format the output - map each reserve to an array of column values
+    
     this.display(
       result.value.map((item) => [
         item.asset.underlying.info.name,
         item.asset.underlying.info.symbol,
         item.spoke.name,
         `${item.chain.name} (${item.chain.chainId})`,
-        `${item.summary.supplyApy.normalized}%`,
-        `${item.summary.borrowApy.normalized}%`,
+        formatApy(item.summary.supplyApy),
+        formatApy(item.summary.borrowApy),
+        `$${item.summary.supplied.fiatAmount.value}`,
+        `$${item.summary.borrowed.fiatAmount.value}`,
+        item.canSupply ? 'Yes' : 'No',
+        item.canBorrow ? 'Yes' : 'No',
+        item.canUseAsCollateral ? 'Yes' : 'No',
         item.id,
       ]),
     );

--- a/packages/cli/src/common.ts
+++ b/packages/cli/src/common.ts
@@ -6,6 +6,8 @@ import {
   evmAddress,
   type HubId,
   hubId,
+  type SpokeId,
+  spokeId,
 } from '@aave/client';
 import { Command, Flags } from '@oclif/core';
 import TtyTable from 'tty-table';
@@ -24,6 +26,14 @@ export const hub = Flags.custom<HubId>({
   description: 'The hub ID (e.g. SGVsbG8h…)',
   helpValue: '<hub-id>',
   parse: async (input) => hubId(input),
+});
+
+export const spoke = Flags.custom<SpokeId>({
+  char: 's',
+  name: 'spoke',
+  description: 'The spoke ID (e.g. SGVsbG8h…)',
+  helpValue: '<spoke-id>',
+  parse: async (input) => spokeId(input),
 });
 
 export const address = Flags.custom<EvmAddress>({

--- a/packages/cli/src/common.ts
+++ b/packages/cli/src/common.ts
@@ -6,8 +6,11 @@ import {
   evmAddress,
   type HubId,
   hubId,
+  local,
+  production,
   type SpokeId,
   spokeId,
+  staging,
 } from '@aave/client';
 import { Command, Flags } from '@oclif/core';
 import TtyTable from 'tty-table';
@@ -41,12 +44,19 @@ export const address = Flags.custom<EvmAddress>({
   helpValue: '<evm-address>',
 });
 
+const environment =
+  process.env.ENVIRONMENT === 'staging'
+    ? staging
+    : process.env.ENVIRONMENT === 'local'
+      ? local
+      : production;
+
 export abstract class V4Command extends Command {
   protected headers: TtyTable.Header[] = [];
 
   public static enableJsonFlag = true;
 
-  protected client = AaveClient.create();
+  protected client = AaveClient.create({ environment: environment });
 
   protected display(rows: unknown[]) {
     const out = TtyTable(this.headers, rows).render();

--- a/packages/cli/src/common.ts
+++ b/packages/cli/src/common.ts
@@ -6,7 +6,6 @@ import {
   evmAddress,
   type HubId,
   hubId,
-  local,
   production,
   type SpokeId,
   spokeId,
@@ -14,8 +13,6 @@ import {
 } from '@aave/client';
 import { Command, Flags } from '@oclif/core';
 import TtyTable from 'tty-table';
-
-
 
 declare global {
   interface BigInt {


### PR DESCRIPTION
Hey, good day, 
I noticed the cli package and was going through it realized there's a lot more commands that could be added to make it even more useful.

I added `reserves list` command 

The command has flexible query options:

- `--spoke_id` - List reserves for a specific spoke
- `--hub_id` - List reserves for a specific hub  
- `--chain_id` - List reserves for a specific chain
- `--hub_address` with `--chain_id` - List reserves for a hub by address

The command displays infos like:

- Asset details (name, symbol)
- Location info (spoke, chain)
- APY rates (supply and borrow, formatted to 4 decimals for readability)
- Liquidity metrics (available liquidity, total borrowed in USD)
- Capabilities (Can Supply, Can Borrow, Can use as Collateral)


 Follows the existing command structure and patterns used in `hubs list` and `spokes list` and updated the cli readme.
 
 screenshot from usage below:

<img width="2329" height="977" alt="--spokes_id" src="https://github.com/user-attachments/assets/3cf7b996-5e92-4ad9-80cf-83e89812be4e" />

<img width="2347" height="1461" alt="--chain_id" src="https://github.com/user-attachments/assets/dd92ee71-6a23-423a-a1b7-74af25627e83" />

<img width="2323" height="1289" alt="--hub_id" src="https://github.com/user-attachments/assets/e6e8e954-70ca-4324-ab7b-981940f8560f" />

<img width="1435" height="785" alt="--help" src="https://github.com/user-attachments/assets/c3f160e1-30f4-4229-bc4b-f83ca7306153" />

<img width="2323" height="1289" alt="--hub_id" src="https://github.com/user-attachments/assets/f63145bb-6984-45af-96c0-f7b5423e054a" />


