### PR TITLE
feat: add curried variant of signTypedDataWith

### DIFF
--- a/.changeset/curried-sign-typed-data.md
+++ b/.changeset/curried-sign-typed-data.md
@@ -1,0 +1,5 @@
+---
+"@aave/client": patch
+---
+
+**feat:** add curried variant of `signTypedDataWith` for Result chaining patterns

--- a/packages/client/src/thirdweb.ts
+++ b/packages/client/src/thirdweb.ts
@@ -37,6 +37,7 @@ import type {
   SignTypedDataError,
   TransactionResult,
   TypedData,
+  TypedDataHandler,
 } from './types';
 
 /**
@@ -275,16 +276,42 @@ function signTypedData(
 }
 
 /**
+ * Creates a function that signs EIP-712 typed data (ERC-20 permits, swap intents, etc.) using the provided Thirdweb wallet.
+ *
+ * @param wallet - The Thirdweb server wallet to use for signing.
+ * @returns A function that takes typed data and returns a ResultAsync containing the raw signature.
+ *
+ * ```ts
+ * const result = await prepareSwapCancel(client, request)
+ *   .andThen(signTypedDataWith(wallet));
+ * ```
+ */
+export function signTypedDataWith(
+  wallet: Engine.ServerWallet,
+): TypedDataHandler;
+
+/**
  * Signs EIP-712 typed data (ERC-20 permits, swap intents, etc.) using the provided Thirdweb wallet.
- * Returns the raw signature without any wrapping. Deadline encapsulation is handled by consumer code.
  *
  * @param wallet - The Thirdweb server wallet to use for signing.
  * @param data - The typed data to sign.
  * @returns A ResultAsync containing the raw signature.
+ *
+ * ```ts
+ * const result = await signTypedDataWith(wallet, typedData);
+ * ```
  */
 export function signTypedDataWith(
   wallet: Engine.ServerWallet,
   data: TypedData,
-): ResultAsync<Signature, SignTypedDataError> {
+): ReturnType<TypedDataHandler>;
+
+export function signTypedDataWith(
+  wallet: Engine.ServerWallet,
+  data?: TypedData,
+): TypedDataHandler | ReturnType<TypedDataHandler> {
+  if (data === undefined) {
+    return (typedData: TypedData) => signTypedData(wallet, typedData);
+  }
   return signTypedData(wallet, data);
 }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -13,7 +13,7 @@ import type {
   PermitTypedData,
   SwapTypedData,
 } from '@aave/graphql';
-import type { ResultAsync, TxHash } from '@aave/types';
+import type { ResultAsync, Signature, TxHash } from '@aave/types';
 
 /**
  * @internal
@@ -49,3 +49,7 @@ export type SignTypedDataError = CancelError | SigningError;
  * Union type for all EIP-712 typed data structures used in the SDK.
  */
 export type TypedData = PermitTypedData | SwapTypedData;
+
+export type TypedDataHandler = (
+  data: TypedData,
+) => ResultAsync<Signature, SignTypedDataError>;


### PR DESCRIPTION
Added function overloads to signTypedDataWith across all wallet adapters (viem, ethers, privy, thirdweb) to support both curried and non-curried usage patterns.

The curried variant enables Result chaining patterns like:
  .andThen(signTypedDataWith(wallet))

The non-curried variant supports direct calls:
  signTypedDataWith(wallet, typedData)

Changes:
- Added TypedDataHandler type to packages/client/src/types.ts
- Updated signTypedDataWith in all adapters with dual overload signatures
- Simplified TSDoc by removing verbose descriptions
- Used cleaner type signatures with TypedDataHandler and ReturnType