### PR TITLE
fix: remove supportedChains dependency from Privy transaction receipt handling

### DIFF
--- a/.changeset/warm-wolves-wait.md
+++ b/.changeset/warm-wolves-wait.md
@@ -1,0 +1,6 @@
+---
+"@aave/client": patch
+"@aave/react": patch
+---
+
+**fix:** remove `supportedChains` dependency from Privy transaction receipt handling

--- a/packages/client/src/viem.ts
+++ b/packages/client/src/viem.ts
@@ -12,7 +12,6 @@ import type {
   TransactionRequest,
 } from '@aave/graphql';
 import {
-  type ChainId,
   chainId,
   errAsync,
   invariant,
@@ -92,30 +91,6 @@ function signTypedData(
     },
   ).map(signatureFrom);
 }
-
-const devnetChain: ViemChain = defineChain({
-  id: Number.parseInt(import.meta.env.ETHEREUM_TENDERLY_FORK_ID, 10),
-  name: 'Devnet',
-  network: 'ethereum-fork',
-  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
-  rpcUrls: {
-    default: { http: [import.meta.env.ETHEREUM_TENDERLY_PUBLIC_RPC] },
-  },
-  blockExplorers: {
-    default: {
-      name: 'Devnet Explorer',
-      url: import.meta.env.ETHEREUM_TENDERLY_BLOCKEXPLORER,
-    },
-  },
-});
-
-/**
- * @internal
- * @deprecated
- */
-export const supportedChains: Record<ChainId, ViemChain> = {
-  [chainId(devnetChain.id)]: devnetChain,
-};
 
 /**
  * @internal

--- a/packages/react/src/misc.ts
+++ b/packages/react/src/misc.ts
@@ -1,5 +1,5 @@
 import type { CurrencyQueryOptions } from '@aave/client';
-import { exchangeRate } from '@aave/client/actions';
+import { exchangeRate, chain as fetchChain } from '@aave/client/actions';
 import type { UnexpectedError } from '@aave/core';
 import type { Chain, ExchangeAmount, ExchangeRateRequest } from '@aave/graphql';
 import {
@@ -104,6 +104,44 @@ export function useChain({
     suspense,
     pause,
   });
+}
+
+/**
+ * Low-level hook to execute a {@link chain} action directly.
+ *
+ * @experimental This hook is experimental and may be subject to breaking changes.
+ * @remarks
+ * This hook **does not** actively watch for updated data on the chain.
+ * Use this hook to retrieve data on demand as part of a larger workflow
+ * (e.g., in an event handler in order to move to the next step).
+ *
+ * ```ts
+ * const [execute, { called, data, error, loading }] = useChainAction();
+ *
+ * // …
+ *
+ * const result = await execute({
+ *   chainId: chainId(1),
+ * });
+ *
+ * if (result.isOk()) {
+ *   console.log(result.value); // Chain | null
+ * } else {
+ *   console.error(result.error);
+ * }
+ * ```
+ */
+export function useChainAction(): UseAsyncTask<
+  ChainRequest,
+  Chain | null,
+  UnexpectedError
+> {
+  const client = useAaveClient();
+
+  return useAsyncTask(
+    (request: ChainRequest) => fetchChain(client, request, { batch: false }),
+    [client],
+  );
 }
 
 export type UseChainsArgs = ChainsRequest;


### PR DESCRIPTION
- Client: use viem's extractChain to dynamically look up chain by chainId
- React: add experimental useChainAction hook, use toViemChain for Privy adapter
- Remove deprecated supportedChains map from viem.ts