### PR TITLE
feat: imperative read hooks default to cache-first request policy

### DIFF
--- a/.changeset/cache-refresh-after-transactions.md
+++ b/.changeset/cache-refresh-after-transactions.md
@@ -1,0 +1,6 @@
+---
+"@aave/client": patch
+"@aave/react": patch
+---
+
+**fix:** ensure cache updates after transactions for cache-first hooks

--- a/.changeset/clever-hounds-watch.md
+++ b/.changeset/clever-hounds-watch.md
@@ -1,0 +1,6 @@
+---
+"@aave/client": patch
+"@aave/react": patch
+---
+
+**feat:** imperative read hooks now default to `cache-first` request policy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,14 @@ The SDK is organized into packages:
 - **Hooks** (`packages/react/src/`): React hooks that wrap actions with reactive state management. Only update when explicitly requested.
 - **Queries/Documents** (`packages/graphql/src/`): GraphQL query definitions and fragments.
 
+**Imperative Read Hooks:**
+React hooks in `@aave/react` that wrap read actions from `@aave/client/actions`. They follow the naming pattern `use[Something]Action` (e.g., `useReservesAction`, `useChainAction`). These hooks use `UseAsyncTask` for async state management and provide an imperative API for executing GraphQL queries. They are distinct from subscription-based or mutation hooks.
+
+Most imperative read hooks default to `cache-first` request policy. **Exceptions** that use `network-only`:
+- `usePreviewAction` - previews must always reflect current on-chain state
+- `useExchangeRateAction` - exchange rates must always be fresh
+- `useTokenSwapQuoteAction`, `useSupplySwapQuoteAction`, `useBorrowSwapQuoteAction`, `useRepayWithSupplyQuoteAction`, `useWithdrawSwapQuoteAction` - swap quotes must reflect current market conditions
+
 When updating GraphQL queries, update corresponding actions. Only update hooks if explicitly requested.
 
 ## Schema updates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,5 +102,5 @@ When creating changesets, create the file manually in `.changeset/` directory si
 - **Always include primary packages** (`@aave/client` and `@aave/react`) when creating changesets for sub-dependencies like `@aave/graphql`, `@aave/types`, or `@aave/core`, since they depend on these packages
 - For changes only to `@aave/cli`, you can omit the primary packages
 - **Changelog description format:** Follow the same conventional commits format as commit messages (e.g., `fix:`, `feat:`, `chore:`, `docs:`), but use **bold** formatting (e.g., `**fix:**`, `**feat:**`, `**chore:**`)
-- **Keep it concise:** One line description only - just the essential change summary
+- **Keep it concise:** One line description only - just the essential change summary. Never use bullet points or multi-line descriptions
 - **Code references:** Use backticks for type names, field names, function names, and other code identifiers (e.g., `` `QuoteAccuracy` ``, `` `spotBuy` ``, `` `SwapQuote` ``)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "release": "pnpm run build && pnpm changeset publish",
     "spec": "vitest --project spec",
     "test:cli": "vitest --project cli --passWithNoTests",
+    "test:client:cache": "vitest --project client packages/client/src/cache.test.ts",
     "test:client:ethers": "vitest --project client packages/client/src/ethers.test.ts",
     "test:client:thirdweb": "vitest --project client packages/client/src/thirdweb.test.ts",
     "test:client:viem": "vitest --project client packages/client/src/viem.test.ts",

--- a/packages/client/src/actions/hubs.ts
+++ b/packages/client/src/actions/hubs.ts
@@ -78,9 +78,16 @@ export function hubs(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
-  }: CurrencyQueryOptions & TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions &
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<Hub[], UnexpectedError> {
-  return client.query(HubsQuery, { request, currency, timeWindow });
+  return client.query(
+    HubsQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }
 
 /**
@@ -103,9 +110,16 @@ export function hubAssets(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
-  }: CurrencyQueryOptions & TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions &
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<HubAsset[], UnexpectedError> {
-  return client.query(HubAssetsQuery, { request, currency, timeWindow });
+  return client.query(
+    HubAssetsQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }
 
 /**
@@ -121,11 +135,15 @@ export function hubAssets(
  *
  * @param client - Aave client.
  * @param request - The hub summary history request parameters.
+ * @param options - The query options.
  * @returns Array of hub summary samples over time.
  */
 export function hubSummaryHistory(
   client: AaveClient,
   request: HubSummaryHistoryRequest,
+  {
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<HubSummarySample[], UnexpectedError> {
-  return client.query(HubSummaryHistoryQuery, { request });
+  return client.query(HubSummaryHistoryQuery, { request }, { requestPolicy });
 }

--- a/packages/client/src/actions/misc.ts
+++ b/packages/client/src/actions/misc.ts
@@ -13,7 +13,11 @@ import {
 } from '@aave/graphql';
 import type { ResultAsync } from '@aave/types';
 import type { AaveClient } from '../AaveClient';
-import { type BatchOptions, DEFAULT_QUERY_OPTIONS } from '../options';
+import {
+  type BatchOptions,
+  DEFAULT_QUERY_OPTIONS,
+  type RequestPolicyOptions,
+} from '../options';
 
 /**
  * Fetches a specific chain by chain ID.
@@ -26,27 +30,18 @@ import { type BatchOptions, DEFAULT_QUERY_OPTIONS } from '../options';
  *
  * @param client - Aave client.
  * @param request - The chain request parameters.
+ * @param options - The query options.
  * @returns The chain data, or null if not found.
  */
-
 export function chain(
   client: AaveClient,
   request: ChainRequest,
-): ResultAsync<Chain | null, UnexpectedError>;
-/**
- * @internal
- */
-export function chain(
-  client: AaveClient,
-  request: ChainRequest,
-  options: BatchOptions,
-): ResultAsync<Chain | null, UnexpectedError>;
-export function chain(
-  client: AaveClient,
-  request: ChainRequest,
-  { batch }: BatchOptions = DEFAULT_QUERY_OPTIONS,
+  {
+    batch = DEFAULT_QUERY_OPTIONS.batch,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: BatchOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<Chain | null, UnexpectedError> {
-  return client.query(ChainQuery, { request }, { batch });
+  return client.query(ChainQuery, { request }, { batch, requestPolicy });
 }
 
 /**
@@ -108,11 +103,15 @@ export function hasProcessedKnownTransaction(
  *
  * @param client - Aave client.
  * @param request - The exchange rate request parameters.
+ * @param options - The query options.
  * @returns The exchange rate information as a fiat amount.
  */
 export function exchangeRate(
   client: AaveClient,
   request: ExchangeRateRequest,
+  {
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<ExchangeAmount, UnexpectedError> {
-  return client.query(ExchangeRateQuery, { request });
+  return client.query(ExchangeRateQuery, { request }, { requestPolicy });
 }

--- a/packages/client/src/actions/reserves.ts
+++ b/packages/client/src/actions/reserves.ts
@@ -16,6 +16,7 @@ import type { AaveClient } from '../AaveClient';
 import {
   type CurrencyQueryOptions,
   DEFAULT_QUERY_OPTIONS,
+  type RequestPolicyOptions,
   type TimeWindowQueryOptions,
 } from '../options';
 
@@ -40,9 +41,16 @@ export function reserve(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
-  }: CurrencyQueryOptions & TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions &
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<Reserve | null, UnexpectedError> {
-  return client.query(ReserveQuery, { request, currency, timeWindow });
+  return client.query(
+    ReserveQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }
 
 /**
@@ -72,9 +80,16 @@ export function reserves(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
-  }: CurrencyQueryOptions & TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions &
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<Reserve[], UnexpectedError> {
-  return client.query(ReservesQuery, { request, currency, timeWindow });
+  return client.query(
+    ReservesQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }
 
 /**
@@ -89,13 +104,17 @@ export function reserves(
  *
  * @param client - Aave client.
  * @param request - The borrow APY history request parameters.
+ * @param options - The query options.
  * @returns The borrow APY history samples.
  */
 export function borrowApyHistory(
   client: AaveClient,
   request: BorrowApyHistoryRequest,
+  {
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<ApySample[], UnexpectedError> {
-  return client.query(BorrowApyHistoryQuery, { request });
+  return client.query(BorrowApyHistoryQuery, { request }, { requestPolicy });
 }
 
 /**
@@ -110,11 +129,15 @@ export function borrowApyHistory(
  *
  * @param client - Aave client.
  * @param request - The supply APY history request parameters.
+ * @param options - The query options.
  * @returns The supply APY history samples.
  */
 export function supplyApyHistory(
   client: AaveClient,
   request: SupplyApyHistoryRequest,
+  {
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<ApySample[], UnexpectedError> {
-  return client.query(SupplyApyHistoryQuery, { request });
+  return client.query(SupplyApyHistoryQuery, { request }, { requestPolicy });
 }

--- a/packages/client/src/actions/swap.ts
+++ b/packages/client/src/actions/swap.ts
@@ -51,6 +51,7 @@ import type { AaveClient } from '../AaveClient';
 import {
   type CurrencyQueryOptions,
   DEFAULT_QUERY_OPTIONS,
+  type RequestPolicyOptions,
   type TimeWindowQueryOptions,
 } from '../options';
 
@@ -78,15 +79,18 @@ import {
 export function tokenSwapQuote(
   client: AaveClient,
   request: TokenSwapQuoteRequest,
-  options: Required<CurrencyQueryOptions> = DEFAULT_QUERY_OPTIONS,
+  {
+    currency = DEFAULT_QUERY_OPTIONS.currency,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<TokenSwapQuoteResult, UnexpectedError> {
   return client.query(
     TokenSwapQuoteQuery,
     {
       request,
-      currency: options.currency,
+      currency,
     },
-    { batch: false },
+    { batch: false, requestPolicy },
   );
 }
 
@@ -101,13 +105,17 @@ export function tokenSwapQuote(
  *
  * @param client - Aave client.
  * @param request - The swappable tokens request parameters.
+ * @param options - The query options.
  * @returns The list of tokens available for swapping.
  */
 export function swappableTokens(
   client: AaveClient,
   request: SwappableTokensRequest,
+  {
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<Token[], UnexpectedError> {
-  return client.query(SwappableTokensQuery, { request });
+  return client.query(SwappableTokensQuery, { request }, { requestPolicy });
 }
 
 /**
@@ -174,13 +182,16 @@ export function prepareTokenSwap(
 export function supplySwapQuote(
   client: AaveClient,
   request: SupplySwapQuoteRequest,
-  options: Required<CurrencyQueryOptions> = DEFAULT_QUERY_OPTIONS,
+  {
+    currency = DEFAULT_QUERY_OPTIONS.currency,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<PositionSwapByIntentApprovalsRequired, UnexpectedError> {
   return client
     .query(
       SupplySwapQuoteQuery,
-      { request, currency: options.currency },
-      { batch: false },
+      { request, currency },
+      { batch: false, requestPolicy },
     )
     .map(extendWithOpaqueType)
     .andThen((result) => {
@@ -217,13 +228,16 @@ export function supplySwapQuote(
 export function borrowSwapQuote(
   client: AaveClient,
   request: BorrowSwapQuoteRequest,
-  options: Required<CurrencyQueryOptions> = DEFAULT_QUERY_OPTIONS,
+  {
+    currency = DEFAULT_QUERY_OPTIONS.currency,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<PositionSwapByIntentApprovalsRequired, UnexpectedError> {
   return client
     .query(
       BorrowSwapQuoteQuery,
-      { request, currency: options.currency },
-      { batch: false },
+      { request, currency },
+      { batch: false, requestPolicy },
     )
     .map(extendWithOpaqueType)
     .andThen((result) => {
@@ -260,13 +274,16 @@ export function borrowSwapQuote(
 export function repayWithSupplyQuote(
   client: AaveClient,
   request: RepayWithSupplyQuoteRequest,
-  options: Required<CurrencyQueryOptions> = DEFAULT_QUERY_OPTIONS,
+  {
+    currency = DEFAULT_QUERY_OPTIONS.currency,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<PositionSwapByIntentApprovalsRequired, UnexpectedError> {
   return client
     .query(
       RepayWithSupplyQuoteQuery,
-      { request, currency: options.currency },
-      { batch: false },
+      { request, currency },
+      { batch: false, requestPolicy },
     )
     .map(extendWithOpaqueType)
     .andThen((result) => {
@@ -303,13 +320,16 @@ export function repayWithSupplyQuote(
 export function withdrawSwapQuote(
   client: AaveClient,
   request: WithdrawSwapQuoteRequest,
-  options: Required<CurrencyQueryOptions> = DEFAULT_QUERY_OPTIONS,
+  {
+    currency = DEFAULT_QUERY_OPTIONS.currency,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<PositionSwapByIntentApprovalsRequired, UnexpectedError> {
   return client
     .query(
       WithdrawSwapQuoteQuery,
-      { request, currency: options.currency },
-      { batch: false },
+      { request, currency },
+      { batch: false, requestPolicy },
     )
     .map(extendWithOpaqueType)
     .andThen((result) => {
@@ -384,9 +404,16 @@ export function swapStatus(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
-  }: CurrencyQueryOptions & TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions &
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<SwapStatus, UnexpectedError> {
-  return client.query(SwapStatusQuery, { request, currency, timeWindow });
+  return client.query(
+    SwapStatusQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }
 
 export type SwapOutcome = SwapCancelled | SwapExpired | SwapFulfilled;
@@ -601,7 +628,14 @@ export function userSwaps(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
-  }: CurrencyQueryOptions & TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions &
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<PaginatedUserSwapsResult, UnexpectedError> {
-  return client.query(UserSwapsQuery, { request, currency, timeWindow });
+  return client.query(
+    UserSwapsQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }

--- a/packages/client/src/actions/transactions.ts
+++ b/packages/client/src/actions/transactions.ts
@@ -364,9 +364,16 @@ export function setSpokeUserPositionManager(
 export function preview(
   client: AaveClient,
   request: PreviewRequest,
-  options: Required<CurrencyQueryOptions> = DEFAULT_QUERY_OPTIONS,
+  {
+    currency = DEFAULT_QUERY_OPTIONS.currency,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<PreviewUserPosition, UnexpectedError> {
-  return client.query(PreviewQuery, { request, ...options });
+  return client.query(
+    PreviewQuery,
+    { request, currency },
+    { requestPolicy },
+  );
 }
 
 /**

--- a/packages/client/src/actions/transactions.ts
+++ b/packages/client/src/actions/transactions.ts
@@ -369,11 +369,7 @@ export function preview(
     requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
   }: CurrencyQueryOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<PreviewUserPosition, UnexpectedError> {
-  return client.query(
-    PreviewQuery,
-    { request, currency },
-    { requestPolicy },
-  );
+  return client.query(PreviewQuery, { request, currency }, { requestPolicy });
 }
 
 /**

--- a/packages/client/src/actions/user.ts
+++ b/packages/client/src/actions/user.ts
@@ -29,6 +29,7 @@ import type { AaveClient } from '../AaveClient';
 import {
   type CurrencyQueryOptions,
   DEFAULT_QUERY_OPTIONS,
+  type RequestPolicyOptions,
   type TimeWindowQueryOptions,
 } from '../options';
 
@@ -58,9 +59,16 @@ export function userSupplies(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
-  }: CurrencyQueryOptions & TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions &
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<UserSupplyItem[], UnexpectedError> {
-  return client.query(UserSuppliesQuery, { request, currency, timeWindow });
+  return client.query(
+    UserSuppliesQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }
 
 /**
@@ -89,13 +97,20 @@ export function userBorrows(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
-  }: CurrencyQueryOptions & TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions &
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<UserBorrowItem[], UnexpectedError> {
-  return client.query(UserBorrowsQuery, { request, currency, timeWindow });
+  return client.query(
+    UserBorrowsQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }
 
 export type UserSummaryQueryOptions = Prettify<
-  CurrencyQueryOptions & TimeWindowQueryOptions
+  CurrencyQueryOptions & TimeWindowQueryOptions & RequestPolicyOptions
 >;
 
 /**
@@ -121,17 +136,23 @@ export function userSummary(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
   }: UserSummaryQueryOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<UserSummary, UnexpectedError> {
-  return client.query(UserSummaryQuery, {
-    request,
-    currency,
-    timeWindow,
-  });
+  return client.query(
+    UserSummaryQuery,
+    {
+      request,
+      currency,
+      timeWindow,
+    },
+    { requestPolicy },
+  );
 }
 
 export type UserPositionQueryOptions = CurrencyQueryOptions &
-  TimeWindowQueryOptions;
+  TimeWindowQueryOptions &
+  RequestPolicyOptions;
 
 /**
  * Fetches all user positions across specified chains.
@@ -157,9 +178,14 @@ export function userPositions(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
   }: UserPositionQueryOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<UserPosition[], UnexpectedError> {
-  return client.query(UserPositionsQuery, { request, currency, timeWindow });
+  return client.query(
+    UserPositionsQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }
 
 /**
@@ -182,9 +208,14 @@ export function userPosition(
   {
     currency = DEFAULT_QUERY_OPTIONS.currency,
     timeWindow = DEFAULT_QUERY_OPTIONS.timeWindow,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
   }: UserPositionQueryOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<UserPosition | null, UnexpectedError> {
-  return client.query(UserPositionQuery, { request, currency, timeWindow });
+  return client.query(
+    UserPositionQuery,
+    { request, currency, timeWindow },
+    { requestPolicy },
+  );
 }
 
 /**
@@ -207,9 +238,16 @@ export function userPosition(
 export function userBalances(
   client: AaveClient,
   request: UserBalancesRequest,
-  options: Required<CurrencyQueryOptions> = DEFAULT_QUERY_OPTIONS,
+  {
+    currency = DEFAULT_QUERY_OPTIONS.currency,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<UserBalance[], UnexpectedError> {
-  return client.query(UserBalancesQuery, { request, ...options });
+  return client.query(
+    UserBalancesQuery,
+    { request, currency },
+    { requestPolicy },
+  );
 }
 
 /**
@@ -233,9 +271,16 @@ export function userBalances(
 export function userSummaryHistory(
   client: AaveClient,
   request: UserSummaryHistoryRequest,
-  options: Required<CurrencyQueryOptions> = DEFAULT_QUERY_OPTIONS,
+  {
+    currency = DEFAULT_QUERY_OPTIONS.currency,
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: CurrencyQueryOptions & RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<UserSummaryHistoryItem[], UnexpectedError> {
-  return client.query(UserSummaryHistoryQuery, { request, ...options });
+  return client.query(
+    UserSummaryHistoryQuery,
+    { request, currency },
+    { requestPolicy },
+  );
 }
 
 /**
@@ -252,11 +297,19 @@ export function userSummaryHistory(
  *
  * @param client - Aave client.
  * @param request - The user risk premium breakdown request parameters.
+ * @param options - The query options.
  * @returns Array of risk premium breakdown items.
  */
 export function userRiskPremiumBreakdown(
   client: AaveClient,
   request: UserRiskPremiumBreakdownRequest,
+  {
+    requestPolicy = DEFAULT_QUERY_OPTIONS.requestPolicy,
+  }: RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): ResultAsync<UserRiskPremiumBreakdownItem[], UnexpectedError> {
-  return client.query(UserRiskPremiumBreakdownQuery, { request });
+  return client.query(
+    UserRiskPremiumBreakdownQuery,
+    { request },
+    { requestPolicy },
+  );
 }

--- a/packages/graphql/src/id.ts
+++ b/packages/graphql/src/id.ts
@@ -327,6 +327,18 @@ export function encodeSpokeId(spoke: SpokeIdParts): SpokeId {
 }
 
 /**
+ * @internal
+ */
+export function decodeSpokeId(value: SpokeId): SpokeIdParts {
+  const decoded = decodeBase64(value);
+  const [a, b] = decoded.split(COMPOSITE_ID_SEPARATOR) as [string, string];
+  return {
+    chainId: chainId(Number.parseInt(a, 10)),
+    address: evmAddress(b),
+  };
+}
+
+/**
  * Creates a spoke identifier from a given base64 value.
  *
  * @remarks

--- a/packages/graphql/src/inputs.ts
+++ b/packages/graphql/src/inputs.ts
@@ -37,6 +37,17 @@ export type AmountInput = ReturnType<typeof graphql.scalar<'AmountInput'>>;
 export type Erc20Input = ReturnType<typeof graphql.scalar<'Erc20Input'>>;
 export type TokenInput = ReturnType<typeof graphql.scalar<'TokenInput'>>;
 export type ReserveInput = ReturnType<typeof graphql.scalar<'ReserveInput'>>;
+
+/**
+ * @internal
+ */
+export function isReserveInputVariant<T>(
+  input: T,
+): input is T & { reserveInput: ReserveInput } {
+  return (
+    isObject(input) && 'reserveInput' in input && input.reserveInput != null
+  );
+}
 export type ReserveAmountInput = ReturnType<
   typeof graphql.scalar<'ReserveAmountInput'>
 >;

--- a/packages/react/src/helpers/cache.ts
+++ b/packages/react/src/helpers/cache.ts
@@ -1,0 +1,169 @@
+import type { AaveClient } from '@aave/client';
+import {
+  decodeUserPositionId,
+  HubsQuery,
+  isChainIdsVariant,
+  isSpokeInputVariant,
+  type ReserveId,
+  ReserveQuery,
+  ReservesQuery,
+  type SpokeInput,
+  SpokeQuery,
+  SpokesQuery,
+  UserBalancesQuery,
+  UserBorrowsQuery,
+  type UserBorrowsRequestQuery,
+  UserPositionQuery,
+  UserPositionsQuery,
+  UserSummaryQuery,
+  UserSuppliesQuery,
+  type UserSuppliesRequestQuery,
+} from '@aave/graphql';
+import type { ChainId, EvmAddress } from '@aave/types';
+
+function extractUserSuppliesRequestUser(
+  query: UserSuppliesRequestQuery,
+): EvmAddress {
+  if ('userSpoke' in query) return query.userSpoke.user;
+  if ('userToken' in query) return query.userToken.user;
+  if ('userChains' in query) return query.userChains.user;
+  if ('userHub' in query) return query.userHub.user;
+
+  const { user } = decodeUserPositionId(query.userPositionId);
+  return user;
+}
+
+function extractUserBorrowsRequestUser(
+  query: UserBorrowsRequestQuery,
+): EvmAddress {
+  if ('userSpoke' in query) return query.userSpoke.user;
+  if ('userToken' in query) return query.userToken.user;
+  if ('userChains' in query) return query.userChains.user;
+  if ('userHub' in query) return query.userHub.user;
+
+  const { user } = decodeUserPositionId(query.userPositionId);
+  return user;
+}
+
+/**
+ * @internal
+ */
+export function refreshUserBalances(client: AaveClient, user: EvmAddress) {
+  return client.refreshQueryWhere(
+    UserBalancesQuery,
+    (variables) => variables.request.user === user,
+  );
+}
+
+/**
+ * @internal
+ */
+export function refreshUserSupplies(client: AaveClient, user: EvmAddress) {
+  return client.refreshQueryWhere(
+    UserSuppliesQuery,
+    (variables) =>
+      extractUserSuppliesRequestUser(variables.request.query) === user,
+  );
+}
+
+/**
+ * @internal
+ */
+export function refreshUserBorrows(client: AaveClient, user: EvmAddress) {
+  return client.refreshQueryWhere(
+    UserBorrowsQuery,
+    (variables) =>
+      extractUserBorrowsRequestUser(variables.request.query) === user,
+  );
+}
+
+/**
+ * @internal
+ */
+export function refreshUserPositions(
+  client: AaveClient,
+  user: EvmAddress,
+  spoke: SpokeInput,
+) {
+  return Promise.all([
+    client.refreshQueryWhere(UserPositionsQuery, (_, data) =>
+      data.some(
+        (position) =>
+          position.spoke.chain.chainId === spoke.chainId &&
+          position.spoke.address === spoke.address &&
+          position.user === user,
+      ),
+    ),
+    client.refreshQueryWhere(
+      UserPositionQuery,
+      (_, data) =>
+        data?.spoke.chain.chainId === spoke.chainId &&
+        data?.spoke.address === spoke.address &&
+        data.user === user,
+    ),
+  ]);
+}
+
+/**
+ * @internal
+ */
+export function refreshReserves(client: AaveClient, id: ReserveId) {
+  return Promise.all([
+    client.refreshQueryWhere(ReserveQuery, (_, data) => data?.id === id),
+    client.refreshQueryWhere(ReservesQuery, (_, data) =>
+      data.some((reserve) => reserve.id === id),
+    ),
+  ]);
+}
+
+/**
+ * @internal
+ */
+export function refreshUserSummary(
+  client: AaveClient,
+  user: EvmAddress,
+  spoke: SpokeInput,
+) {
+  return client.refreshQueryWhere(UserSummaryQuery, (variables) =>
+    variables.request.user === user &&
+    isSpokeInputVariant(variables.request.filter)
+      ? variables.request.filter.spoke.chainId === spoke.chainId &&
+        variables.request.filter.spoke.address === spoke.address
+      : isChainIdsVariant(variables.request.filter)
+        ? variables.request.filter.chainIds.some((id) => id === spoke.chainId)
+        : false,
+  );
+}
+
+/**
+ * @internal
+ */
+export function refreshSpokes(client: AaveClient, spoke: SpokeInput) {
+  return Promise.all([
+    client.refreshQueryWhere(
+      SpokeQuery,
+      (_, data) =>
+        data?.chain.chainId === spoke.chainId &&
+        data?.address === spoke.address,
+    ),
+    client.refreshQueryWhere(SpokesQuery, (_, data) =>
+      data.some(
+        (item) =>
+          item.chain.chainId === spoke.chainId &&
+          item.address === spoke.address,
+      ),
+    ),
+  ]);
+}
+
+/**
+ * @internal
+ */
+export function refreshHubs(client: AaveClient, chainId: ChainId) {
+  return client.refreshQueryWhere(
+    HubsQuery,
+    (variables) =>
+      isChainIdsVariant(variables.request) &&
+      variables.request.chainIds.some((id) => id === chainId),
+  );
+}

--- a/packages/react/src/helpers/index.ts
+++ b/packages/react/src/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from './cache';
 export * from './reads';
 export * from './results';
 export * from './tasks';

--- a/packages/react/src/hubs.ts
+++ b/packages/react/src/hubs.ts
@@ -402,7 +402,10 @@ export function useHubsAction(
 
   return useAsyncTask(
     (request: HubsRequest) =>
-      hubs(client, request, { currency: options.currency }),
+      hubs(client, request, {
+        currency: options.currency,
+        requestPolicy: 'cache-first',
+      }),
     [client, options.currency],
   );
 }

--- a/packages/react/src/misc.ts
+++ b/packages/react/src/misc.ts
@@ -139,7 +139,11 @@ export function useChainAction(): UseAsyncTask<
   const client = useAaveClient();
 
   return useAsyncTask(
-    (request: ChainRequest) => fetchChain(client, request, { batch: false }),
+    (request: ChainRequest) =>
+      fetchChain(client, request, {
+        batch: false,
+        requestPolicy: 'cache-first',
+      }),
     [client],
   );
 }
@@ -252,7 +256,8 @@ export function useExchangeRateAction(): UseAsyncTask<
   const client = useAaveClient();
 
   return useAsyncTask(
-    (request: ExchangeRateRequest) => exchangeRate(client, request),
+    (request: ExchangeRateRequest) =>
+      exchangeRate(client, request, { requestPolicy: 'network-only' }),
     [client],
   );
 }

--- a/packages/react/src/reserves.ts
+++ b/packages/react/src/reserves.ts
@@ -156,6 +156,7 @@ export function useReserveAction(
       reserve(client, request, {
         currency: options.currency ?? DEFAULT_QUERY_OPTIONS.currency,
         timeWindow: options.timeWindow ?? DEFAULT_QUERY_OPTIONS.timeWindow,
+        requestPolicy: 'cache-first',
       }),
     [client, options.currency, options.timeWindow],
   );
@@ -409,6 +410,7 @@ export function useReservesAction(
       reserves(client, request, {
         currency: options.currency ?? DEFAULT_QUERY_OPTIONS.currency,
         timeWindow: options.timeWindow ?? DEFAULT_QUERY_OPTIONS.timeWindow,
+        requestPolicy: 'cache-first',
       }),
     [client, options.currency, options.timeWindow],
   );

--- a/packages/react/src/swap.ts
+++ b/packages/react/src/swap.ts
@@ -309,9 +309,10 @@ export function useTokenSwapQuoteAction(
 
   return useAsyncTask(
     (request: TokenSwapQuoteRequest) =>
-      tokenSwapQuote(client, request, { currency: options.currency }).map(
-        extractTokenSwapQuote,
-      ),
+      tokenSwapQuote(client, request, {
+        currency: options.currency,
+        requestPolicy: 'network-only',
+      }).map(extractTokenSwapQuote),
     [client, options.currency],
   );
 }
@@ -745,9 +746,10 @@ export function useSupplySwapQuoteAction(
 
   return useAsyncTask(
     (request: SupplySwapQuoteRequest) =>
-      supplySwapQuote(client, request, { currency: options.currency }).map(
-        (data) => data.quote,
-      ),
+      supplySwapQuote(client, request, {
+        currency: options.currency,
+        requestPolicy: 'network-only',
+      }).map((data) => data.quote),
     [client, options.currency],
   );
 }
@@ -891,9 +893,10 @@ export function useBorrowSwapQuoteAction(
 
   return useAsyncTask(
     (request: BorrowSwapQuoteRequest) =>
-      borrowSwapQuote(client, request, { currency: options.currency }).map(
-        (data) => data.quote,
-      ),
+      borrowSwapQuote(client, request, {
+        currency: options.currency,
+        requestPolicy: 'network-only',
+      }).map((data) => data.quote),
     [client, options.currency],
   );
 }
@@ -1234,9 +1237,10 @@ export function useRepayWithSupplyQuoteAction(
 
   return useAsyncTask(
     (request: RepayWithSupplyQuoteRequest) =>
-      repayWithSupplyQuote(client, request, { currency: options.currency }).map(
-        (data) => data.quote,
-      ),
+      repayWithSupplyQuote(client, request, {
+        currency: options.currency,
+        requestPolicy: 'network-only',
+      }).map((data) => data.quote),
     [client, options.currency],
   );
 }
@@ -1434,9 +1438,10 @@ export function useWithdrawSwapQuoteAction(
 
   return useAsyncTask(
     (request: WithdrawSwapQuoteRequest) =>
-      withdrawSwapQuote(client, request, { currency: options.currency }).map(
-        (data) => data.quote,
-      ),
+      withdrawSwapQuote(client, request, {
+        currency: options.currency,
+        requestPolicy: 'network-only',
+      }).map((data) => data.quote),
     [client, options.currency],
   );
 }

--- a/packages/react/src/transactions.ts
+++ b/packages/react/src/transactions.ts
@@ -44,12 +44,12 @@ import {
   ReservesQuery,
   type SetSpokeUserPositionManagerRequest,
   type SetUserSuppliesAsCollateralRequest,
+  type SpokeInput,
   SpokePositionManagersQuery,
   SpokesQuery,
   type SupplyRequest,
   type TransactionRequest,
   type UpdateUserPositionConditionsRequest,
-  UserBalancesQuery,
   UserPositionQuery,
   UserPositionsQuery,
   UserSummaryQuery,
@@ -73,6 +73,14 @@ import {
   PendingTransaction,
   type PendingTransactionError,
   type ReadResult,
+  refreshHubs,
+  refreshReserves,
+  refreshSpokes,
+  refreshUserBalances,
+  refreshUserBorrows,
+  refreshUserPositions,
+  refreshUserSummary,
+  refreshUserSupplies,
   type SendTransactionError,
   type Suspendable,
   type SuspendableResult,
@@ -87,65 +95,18 @@ function refreshQueriesForReserveChange(
   client: AaveClient,
   request: SupplyRequest | BorrowRequest | RepayRequest | WithdrawRequest,
 ) {
-  const { chainId, spoke } = decodeReserveId(request.reserve);
+  const { chainId, spoke: address } = decodeReserveId(request.reserve);
+  const spoke: SpokeInput = { chainId, address };
   return async () =>
     Promise.all([
-      // update user positions
-      await client.refreshQueryWhere(
-        UserPositionsQuery,
-        (variables, data) =>
-          variables.request.user === request.sender &&
-          data.some(
-            (position) =>
-              position.spoke.chain.chainId === chainId &&
-              position.spoke.address === spoke,
-          ),
-      ),
-      await client.refreshQueryWhere(
-        UserPositionQuery,
-        (_, data) =>
-          data?.spoke.chain.chainId === chainId &&
-          data?.spoke.address === spoke &&
-          data.user === request.sender,
-      ),
-
-      // update user summary
-      await client.refreshQueryWhere(UserSummaryQuery, (variables) =>
-        variables.request.user === request.sender &&
-        isSpokeInputVariant(variables.request.filter)
-          ? variables.request.filter.spoke.chainId === chainId &&
-            variables.request.filter.spoke.address === spoke
-          : isChainIdsVariant(variables.request.filter)
-            ? variables.request.filter.chainIds.some((id) => id === chainId)
-            : false,
-      ),
-
-      // update reserves
-      await client.refreshQueryWhere(ReservesQuery, (_, data) =>
-        data.some((reserve) => reserve.id === request.reserve),
-      ),
-
-      // update spokes
-      await client.refreshQueryWhere(SpokesQuery, (_, data) =>
-        data.some(
-          (item) => item.chain.chainId === chainId && item.address === spoke,
-        ),
-      ),
-
-      // update user balances
-      await client.refreshQueryWhere(
-        UserBalancesQuery,
-        // update any user balances for the given user
-        (variables) => variables.request.user === request.sender,
-      ),
-
-      // update hubs
-      await client.refreshQueryWhere(
-        HubsQuery,
-        (variables) =>
-          isChainIdsVariant(variables.request) &&
-          variables.request.chainIds.some((id) => id === chainId),
-      ),
+      refreshUserPositions(client, request.sender, spoke),
+      refreshUserSummary(client, request.sender, spoke),
+      refreshReserves(client, request.reserve),
+      refreshSpokes(client, spoke),
+      refreshUserBalances(client, request.sender),
+      refreshUserSupplies(client, request.sender),
+      refreshUserBorrows(client, request.sender),
+      refreshHubs(client, chainId),
     ]);
 }
 

--- a/packages/react/src/transactions.ts
+++ b/packages/react/src/transactions.ts
@@ -1167,7 +1167,10 @@ export function usePreviewAction(
 
   return useAsyncTask(
     (request: PreviewRequest) =>
-      preview(client, request, { currency: options.currency }),
+      preview(client, request, {
+        currency: options.currency,
+        requestPolicy: 'network-only',
+      }),
     [client, options.currency],
   );
 }
@@ -1424,6 +1427,7 @@ export function useActivitiesAction(
       activities(client, request, {
         currency: options.currency ?? DEFAULT_QUERY_OPTIONS.currency,
         timeWindow: options.timeWindow ?? DEFAULT_QUERY_OPTIONS.timeWindow,
+        requestPolicy: 'cache-first',
       }),
     [client, options.currency, options.timeWindow],
   );

--- a/packages/react/src/user.ts
+++ b/packages/react/src/user.ts
@@ -209,6 +209,7 @@ export function useUserSuppliesAction(
       userSupplies(client, request, {
         currency: options.currency ?? DEFAULT_QUERY_OPTIONS.currency,
         timeWindow: options.timeWindow ?? DEFAULT_QUERY_OPTIONS.timeWindow,
+        requestPolicy: 'cache-first',
       }),
     [client, options.currency, options.timeWindow],
   );
@@ -365,6 +366,7 @@ export function useUserBorrowsAction(
       userBorrows(client, request, {
         currency: options.currency ?? DEFAULT_QUERY_OPTIONS.currency,
         timeWindow: options.timeWindow ?? DEFAULT_QUERY_OPTIONS.timeWindow,
+        requestPolicy: 'cache-first',
       }),
     [client, options.currency, options.timeWindow],
   );
@@ -599,6 +601,7 @@ export function useUserPositionsAction(
       userPositions(client, request, {
         currency: options.currency,
         timeWindow: options.timeWindow,
+        requestPolicy: 'cache-first',
       }),
     [client, options.currency, options.timeWindow],
   );
@@ -907,7 +910,10 @@ export function useUserBalancesAction(
 
   return useAsyncTask(
     (request: UserBalancesRequest) =>
-      userBalances(client, request, { currency: options.currency }),
+      userBalances(client, request, {
+        currency: options.currency,
+        requestPolicy: 'cache-first',
+      }),
     [client, options.currency],
   );
 }


### PR DESCRIPTION
- Client actions updated to accept optional requestPolicy parameter
- Imperative read hooks now pass cache-first by default
- Exceptions use network-only: usePreviewAction, useExchangeRateAction, and all swap quote action hooks (token, supply, borrow, repay, withdraw)
- Added documentation to AGENTS.md about imperative read hooks