### PR TITLE
feat: added requestpolicy overrides and add refreshUserSupplies

### DIFF
--- a/packages/react/src/reserves.ts
+++ b/packages/react/src/reserves.ts
@@ -1,6 +1,7 @@
 import {
   type CurrencyQueryOptions,
   DEFAULT_QUERY_OPTIONS,
+  RequestPolicyOptions,
   type TimeWindowQueryOptions,
   type UnexpectedError,
 } from '@aave/client';
@@ -147,7 +148,8 @@ export function useReserve({
  */
 export function useReserveAction(
   options: CurrencyQueryOptions &
-    TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): UseAsyncTask<ReserveRequest, Reserve | null, UnexpectedError> {
   const client = useAaveClient();
 
@@ -156,9 +158,9 @@ export function useReserveAction(
       reserve(client, request, {
         currency: options.currency ?? DEFAULT_QUERY_OPTIONS.currency,
         timeWindow: options.timeWindow ?? DEFAULT_QUERY_OPTIONS.timeWindow,
-        requestPolicy: 'cache-first',
+        requestPolicy: options.requestPolicy ?? 'cache-first',
       }),
-    [client, options.currency, options.timeWindow],
+    [client, options.currency, options.timeWindow, options.requestPolicy],
   );
 }
 

--- a/packages/react/src/transactions.ts
+++ b/packages/react/src/transactions.ts
@@ -897,6 +897,9 @@ export function useSetUserSuppliesAsCollateral(
               ),
             ),
 
+            // update user supplies
+            refreshUserSupplies(client, request.sender),
+
             // update hubs
             ...reserveDetails.map(({ chainId }) =>
               client.refreshQueryWhere(

--- a/packages/react/src/user.ts
+++ b/packages/react/src/user.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_QUERY_OPTIONS,
   type TimeWindowQueryOptions,
   type UnexpectedError,
+  RequestPolicyOptions,
 } from '@aave/client';
 import type { UserPositionQueryOptions } from '@aave/client/actions';
 import {
@@ -200,7 +201,8 @@ export function useUserSupplies({
  */
 export function useUserSuppliesAction(
   options: CurrencyQueryOptions &
-    TimeWindowQueryOptions = DEFAULT_QUERY_OPTIONS,
+    TimeWindowQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): UseAsyncTask<UserSuppliesRequest, UserSupplyItem[], UnexpectedError> {
   const client = useAaveClient();
 
@@ -209,9 +211,9 @@ export function useUserSuppliesAction(
       userSupplies(client, request, {
         currency: options.currency ?? DEFAULT_QUERY_OPTIONS.currency,
         timeWindow: options.timeWindow ?? DEFAULT_QUERY_OPTIONS.timeWindow,
-        requestPolicy: 'cache-first',
+        requestPolicy: options.requestPolicy ?? 'cache-first',
       }),
-    [client, options.currency, options.timeWindow],
+    [client, options.currency, options.timeWindow, options.requestPolicy],
   );
 }
 
@@ -592,7 +594,8 @@ export function useUserPositions({
  * ```
  */
 export function useUserPositionsAction(
-  options: UserPositionQueryOptions = DEFAULT_QUERY_OPTIONS,
+  options: UserPositionQueryOptions &
+    RequestPolicyOptions = DEFAULT_QUERY_OPTIONS,
 ): UseAsyncTask<UserPositionsRequest, UserPosition[], UnexpectedError> {
   const client = useAaveClient();
 
@@ -601,9 +604,9 @@ export function useUserPositionsAction(
       userPositions(client, request, {
         currency: options.currency,
         timeWindow: options.timeWindow,
-        requestPolicy: 'cache-first',
+        requestPolicy: options.requestPolicy ?? 'cache-first',
       }),
-    [client, options.currency, options.timeWindow],
+    [client, options.currency, options.timeWindow, options.requestPolicy],
   );
 }
 


### PR DESCRIPTION
## GENERAL CHANGES

* The global default setting was changed to `cache-first`.

  <img width="908" height="215" alt="Screenshot 2026-01-30 at 3 44 48 PM" src="https://github.com/user-attachments/assets/46c33b7b-e5da-4f9a-a308-f62558d2ca20" />

This has broken a few UI flows. For example, enable-collateral: since the cache is kept, the requests are not re-triggered and the data becomes stale, which breaks the next steps in the flow.

* I added a refresh of `userSupplies` inside `useSetUserSuppliesAsCollateral`, because now that we use `cache-first` by default it was causing issues.

* Keeping the global change to use `cache-first`, I added the ability to override the cache behavior in actions such as `useUserSuppliesAction`, `useReserveAction`, and `useUserPositionsAction`.
