### PR TITLE
fix: resolve Safe wallet safeTxHash to on-chain hash

### DIFF
--- a/.changeset/safe-tx-hash-resolution.md
+++ b/.changeset/safe-tx-hash-resolution.md
@@ -1,0 +1,5 @@
+---
+"@aave/client": patch
+---
+
+Fix Safe wallet transaction flow by resolving safeTxHash to on-chain hash before waiting for receipt. Adds iframe detection and Safe Apps SDK integration with zero overhead for non-Safe users.

--- a/.changeset/safe-tx-hash-resolution.md
+++ b/.changeset/safe-tx-hash-resolution.md
@@ -1,5 +1,6 @@
 ---
 "@aave/client": patch
+"@aave/react": patch
 ---
 
 Fix Safe wallet transaction flow by resolving safeTxHash to on-chain hash before waiting for receipt. Adds iframe detection and Safe Apps SDK integration with zero overhead for non-Safe users.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -96,6 +96,7 @@
   },
   "devDependencies": {
     "@bgd-labs/aave-address-book": "^4.25.3",
+    "@safe-global/safe-apps-sdk": "^9.1.0",
     "@node-kit/pnpm-workspace-root": "^3.3.1",
     "@privy-io/server-auth": "^1.32.5",
     "dotenv": "^17.2.3",
@@ -109,6 +110,7 @@
   },
   "peerDependencies": {
     "@privy-io/server-auth": "^1.28.8",
+    "@safe-global/safe-apps-sdk": ">=9.0.0",
     "ethers": "^6.14.4",
     "thirdweb": "^5.105.25",
     "viem": "^2.47.0"
@@ -118,6 +120,9 @@
       "optional": true
     },
     "@privy-io/server-auth": {
+      "optional": true
+    },
+    "@safe-global/safe-apps-sdk": {
       "optional": true
     },
     "thirdweb": {

--- a/packages/client/src/ethers.ts
+++ b/packages/client/src/ethers.ts
@@ -28,6 +28,7 @@ import {
   type TypedDataField,
 } from 'ethers';
 import { supportsPermit } from './adapters';
+import { resolveTxHash } from './safe';
 import type {
   ExecutionPlanHandler,
   SignTypedDataError,
@@ -101,24 +102,32 @@ export function waitForTransactionResult(
   request: TransactionRequest,
   response: TransactionResponse,
 ): ResultAsync<TransactionResult, TransactionError | UnexpectedError> {
-  return ResultAsync.fromPromise(response.wait(), (err) =>
-    UnexpectedError.from(err),
-  ).andThen((receipt) => {
-    const hash = txHash(nonNullable(receipt?.hash));
+  return ResultAsync.fromPromise(
+    resolveTxHash(txHash(response.hash)),
+    (err) => UnexpectedError.from(err),
+  ).andThen((resolvedHash) =>
+    ResultAsync.fromPromise(
+      resolvedHash !== txHash(response.hash)
+        ? response.provider!.waitForTransaction(resolvedHash)
+        : response.wait(),
+      (err) => UnexpectedError.from(err),
+    ).andThen((receipt) => {
+      const hash = txHash(nonNullable(receipt?.hash));
 
-    if (receipt?.status === 0) {
-      return errAsync(
-        TransactionError.new({
-          txHash: hash,
-          request,
-        }),
-      );
-    }
-    return okAsync({
-      txHash: hash,
-      operations: request.operations,
-    });
-  });
+      if (receipt?.status === 0) {
+        return errAsync(
+          TransactionError.new({
+            txHash: hash,
+            request,
+          }),
+        );
+      }
+      return okAsync({
+        txHash: hash,
+        operations: request.operations,
+      });
+    }),
+  );
 }
 
 function sendTransactionAndWait(

--- a/packages/client/src/ethers.ts
+++ b/packages/client/src/ethers.ts
@@ -108,7 +108,7 @@ export function waitForTransactionResult(
   ).andThen((resolvedHash) =>
     ResultAsync.fromPromise(
       resolvedHash !== txHash(response.hash)
-        ? response.provider!.waitForTransaction(resolvedHash)
+        ? nonNullable(response.provider).waitForTransaction(resolvedHash)
         : response.wait(),
       (err) => UnexpectedError.from(err),
     ).andThen((receipt) => {

--- a/packages/client/src/ethers.ts
+++ b/packages/client/src/ethers.ts
@@ -102,9 +102,8 @@ export function waitForTransactionResult(
   request: TransactionRequest,
   response: TransactionResponse,
 ): ResultAsync<TransactionResult, TransactionError | UnexpectedError> {
-  return ResultAsync.fromPromise(
-    resolveTxHash(txHash(response.hash)),
-    (err) => UnexpectedError.from(err),
+  return ResultAsync.fromPromise(resolveTxHash(txHash(response.hash)), (err) =>
+    UnexpectedError.from(err),
   ).andThen((resolvedHash) =>
     ResultAsync.fromPromise(
       resolvedHash !== txHash(response.hash)

--- a/packages/client/src/safe.ts
+++ b/packages/client/src/safe.ts
@@ -50,7 +50,7 @@ async function getSafeSDK(): Promise<any | null> {
  * Returns true if running inside a Safe App iframe.
  * Synchronous false for non-iframe contexts.
  */
-export async function isSafeWallet(): Promise<boolean> {
+async function isSafeWallet(): Promise<boolean> {
   if (!isInIframe()) return false;
   if (_isSafe !== null) return _isSafe;
 

--- a/packages/client/src/safe.ts
+++ b/packages/client/src/safe.ts
@@ -8,10 +8,7 @@ let _sdk: any = null;
 const SAFE_POLL_INTERVAL_MS = 2000;
 const SAFE_POLL_TIMEOUT_MS = 5 * 60 * 1000;
 const SAFE_INFO_TIMEOUT_MS = 200;
-const SAFE_ALLOWED_DOMAINS: RegExp[] = [
-  /gnosis-safe\.io$/,
-  /app\.safe\.global$/,
-];
+const SAFE_ALLOWED_DOMAINS: RegExp[] = [/^app\.safe\.global$/];
 
 declare const self: unknown;
 

--- a/packages/client/src/safe.ts
+++ b/packages/client/src/safe.ts
@@ -1,0 +1,98 @@
+import type { TxHash } from '@aave/types';
+import { txHash } from '@aave/types';
+
+let _isSafe: boolean | null = null;
+// biome-ignore lint/suspicious/noExplicitAny: Safe SDK loaded dynamically, types not guaranteed
+let _sdk: any = null;
+
+const SAFE_POLL_INTERVAL_MS = 2000;
+const SAFE_POLL_TIMEOUT_MS = 5 * 60 * 1000;
+const SAFE_INFO_TIMEOUT_MS = 200;
+
+declare const self: unknown;
+
+function isInIframe(): boolean {
+  try {
+    if (typeof globalThis === 'undefined') return false;
+    if (typeof self === 'undefined') return false;
+    // biome-ignore lint/suspicious/noExplicitAny: accessing window properties across environments
+    const w = globalThis as any;
+    return (
+      typeof w.self !== 'undefined' &&
+      typeof w.top !== 'undefined' &&
+      w.self !== w.top
+    );
+  } catch {
+    return true; // cross-origin iframe
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: Safe SDK loaded dynamically, types not guaranteed
+async function getSafeSDK(): Promise<any | null> {
+  if (_sdk) return _sdk;
+  try {
+    // Dynamic import so consumers without @safe-global/safe-apps-sdk installed
+    // don't get a hard failure at module load time (it's an optional peer dep).
+    const mod = await import(
+      /* webpackIgnore: true */ '@safe-global/safe-apps-sdk'
+    );
+    const SDK = mod.default ?? mod;
+    _sdk = new SDK();
+    return _sdk;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true if running inside a Safe App iframe.
+ * Synchronous false for non-iframe contexts.
+ */
+export async function isSafeWallet(): Promise<boolean> {
+  if (!isInIframe()) return false;
+  if (_isSafe !== null) return _isSafe;
+
+  try {
+    const sdk = await getSafeSDK();
+    if (!sdk) {
+      _isSafe = false;
+      return false;
+    }
+
+    const info = await Promise.race([
+      sdk.safe.getInfo(),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), SAFE_INFO_TIMEOUT_MS),
+      ),
+    ]);
+    _isSafe = !!info;
+  } catch {
+    _isSafe = false;
+  }
+  return _isSafe;
+}
+
+/**
+ * If running in a Safe iframe, resolves a safeTxHash to the on-chain
+ * transaction hash by polling the Safe SDK. Returns the hash unchanged
+ * for non-Safe contexts.
+ */
+export async function resolveTxHash(hash: TxHash): Promise<TxHash> {
+  if (!(await isSafeWallet())) return hash;
+
+  const sdk = await getSafeSDK();
+  if (!sdk) return hash;
+
+  const deadline = Date.now() + SAFE_POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      const safeTx = await sdk.txs.getBySafeTxHash(hash);
+      if (safeTx?.txHash) return txHash(safeTx.txHash);
+    } catch {
+      // not yet executed, retry
+    }
+    await new Promise((r) => setTimeout(r, SAFE_POLL_INTERVAL_MS));
+  }
+
+  return hash;
+}

--- a/packages/client/src/safe.ts
+++ b/packages/client/src/safe.ts
@@ -8,6 +8,10 @@ let _sdk: any = null;
 const SAFE_POLL_INTERVAL_MS = 2000;
 const SAFE_POLL_TIMEOUT_MS = 5 * 60 * 1000;
 const SAFE_INFO_TIMEOUT_MS = 200;
+const SAFE_ALLOWED_DOMAINS: RegExp[] = [
+  /gnosis-safe\.io$/,
+  /app\.safe\.global$/,
+];
 
 declare const self: unknown;
 
@@ -33,11 +37,9 @@ async function getSafeSDK(): Promise<any | null> {
   try {
     // Dynamic import so consumers without @safe-global/safe-apps-sdk installed
     // don't get a hard failure at module load time (it's an optional peer dep).
-    const mod = await import(
-      /* webpackIgnore: true */ '@safe-global/safe-apps-sdk'
-    );
+    const mod = await import('@safe-global/safe-apps-sdk');
     const SDK = mod.default ?? mod;
-    _sdk = new SDK();
+    _sdk = new SDK({ allowedDomains: SAFE_ALLOWED_DOMAINS });
     return _sdk;
   } catch {
     return null;

--- a/packages/client/src/viem.ts
+++ b/packages/client/src/viem.ts
@@ -457,5 +457,3 @@ export function permitWith<E>(
     return okAsync(result);
   });
 }
-
-export { isSafeWallet } from './safe';

--- a/packages/client/src/viem.ts
+++ b/packages/client/src/viem.ts
@@ -44,6 +44,8 @@ import { mainnet, sepolia } from 'viem/chains';
 import type { AaveClient } from './AaveClient';
 import { chain as fetchChain } from './actions';
 import { supportsPermit } from './adapters';
+import { resolveTxHash } from './safe';
+export { isSafeWallet } from './safe';
 import type {
   ExecutionPlanHandler,
   SignTypedDataError,
@@ -282,31 +284,36 @@ export function waitForTransactionResult(
   CancelError | TransactionError | UnexpectedError
 > {
   return ResultAsync.fromPromise(
-    waitForTransactionReceipt(walletClient, {
-      hash: initialTxHash,
-      pollingInterval: 100,
-      retryCount: 20,
-      retryDelay: 50,
-    }),
+    resolveTxHash(initialTxHash),
     (err) => UnexpectedError.from(err),
-  ).andThen((receipt) => {
-    const hash = txHash(receipt.transactionHash);
+  ).andThen((resolvedHash) =>
+    ResultAsync.fromPromise(
+      waitForTransactionReceipt(walletClient, {
+        hash: resolvedHash,
+        pollingInterval: 100,
+        retryCount: 20,
+        retryDelay: 50,
+      }),
+      (err) => UnexpectedError.from(err),
+    ).andThen((receipt) => {
+      const hash = txHash(receipt.transactionHash);
 
-    switch (receipt.status) {
-      case 'reverted':
-        if (initialTxHash !== hash) {
-          return errAsync(CancelError.from(`Transaction replaced by ${hash}`));
-        }
-        return errAsync(transactionError(walletClient.chain, hash, request));
-      case 'success':
-        return okAsync({
-          // viem's waitForTransactionReceipt supports transaction replacement
-          // so it's important to use the transaction hash from the receipt
-          txHash: hash,
-          operations: request.operations,
-        });
-    }
-  });
+      switch (receipt.status) {
+        case 'reverted':
+          if (resolvedHash !== hash) {
+            return errAsync(
+              CancelError.from(`Transaction replaced by ${hash}`),
+            );
+          }
+          return errAsync(transactionError(walletClient.chain, hash, request));
+        case 'success':
+          return okAsync({
+            txHash: hash,
+            operations: request.operations,
+          });
+      }
+    }),
+  );
 }
 
 function sendTransactionAndWait(

--- a/packages/client/src/viem.ts
+++ b/packages/client/src/viem.ts
@@ -282,9 +282,8 @@ export function waitForTransactionResult(
   TransactionResult,
   CancelError | TransactionError | UnexpectedError
 > {
-  return ResultAsync.fromPromise(
-    resolveTxHash(initialTxHash),
-    (err) => UnexpectedError.from(err),
+  return ResultAsync.fromPromise(resolveTxHash(initialTxHash), (err) =>
+    UnexpectedError.from(err),
   ).andThen((resolvedHash) =>
     ResultAsync.fromPromise(
       waitForTransactionReceipt(walletClient, {

--- a/packages/client/src/viem.ts
+++ b/packages/client/src/viem.ts
@@ -45,7 +45,6 @@ import type { AaveClient } from './AaveClient';
 import { chain as fetchChain } from './actions';
 import { supportsPermit } from './adapters';
 import { resolveTxHash } from './safe';
-export { isSafeWallet } from './safe';
 import type {
   ExecutionPlanHandler,
   SignTypedDataError,
@@ -459,3 +458,5 @@ export function permitWith<E>(
     return okAsync(result);
   });
 }
+
+export { isSafeWallet } from './safe';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@privy-io/server-auth':
         specifier: ^1.32.5
         version: 1.32.5(bufferutil@4.0.9)(encoding@0.1.13)(ethers@6.14.4(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.47.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@safe-global/safe-apps-sdk':
+        specifier: ^9.1.0
+        version: 9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -2255,6 +2258,13 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@safe-global/safe-apps-sdk@9.1.0':
+    resolution: {integrity: sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==}
+
+  '@safe-global/safe-gateway-typescript-sdk@3.23.1':
+    resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
+    engines: {node: '>=16'}
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -9316,6 +9326,18 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@safe-global/safe-gateway-typescript-sdk': 3.23.1
+      viem: 2.47.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@safe-global/safe-gateway-typescript-sdk@3.23.1': {}
 
   '@scure/base@1.1.9': {}
 


### PR DESCRIPTION
## Summary

- When running as a Safe App (iframe at app.safe.global), `sendTransaction` returns a safeTxHash instead of the on-chain tx hash, causing `waitForTransactionReceipt` to fail
- Adds `packages/client/src/safe.ts` with iframe detection (`isInIframe()`) + Safe Apps SDK integration to resolve safeTxHash to the real on-chain hash
- Both viem and ethers adapters call `resolveTxHash()` before polling for receipt
- Zero overhead for non-iframe users (synchronous bool check returns false)
- `@safe-global/safe-apps-sdk` added as optional peer dependency, dynamically imported only when in iframe
- Exports `isSafeWallet()` as public utility from `@aave/client/viem`


https://linear.app/aavelabs/issue/AAVE-4203/fix-safe-wallet-tx-hash-resolution-in-sdk

Closes AAVE-4203