### PR TITLE
fix: Safe wallet detection broken by allowedDomains regex

### DIFF
--- a/.changeset/fix-safe-domains.md
+++ b/.changeset/fix-safe-domains.md
@@ -1,0 +1,5 @@
+---
+"@aave/client": patch
+---
+
+Fix Safe wallet detection failing due to allowedDomains regex not matching the full origin (https://app.safe.global). Also restore webpackIgnore comment for dynamic import and increase getInfo timeout from 200ms to 5s.

--- a/packages/client/src/safe.ts
+++ b/packages/client/src/safe.ts
@@ -7,8 +7,8 @@ let _sdk: any = null;
 
 const SAFE_POLL_INTERVAL_MS = 2000;
 const SAFE_POLL_TIMEOUT_MS = 5 * 60 * 1000;
-const SAFE_INFO_TIMEOUT_MS = 200;
-const SAFE_ALLOWED_DOMAINS: RegExp[] = [/^app\.safe\.global$/];
+const SAFE_INFO_TIMEOUT_MS = 5000;
+const SAFE_ALLOWED_DOMAINS: RegExp[] = [/app\.safe\.global$/];
 
 declare const self: unknown;
 


### PR DESCRIPTION
## Summary

- Fix regex `/^app\.safe\.global$/` to `/safe\.global$/` so it matches the full browser origin `https://app.safe.global`
- Bump `getInfo()` timeout from 200ms to 5s (postMessage roundtrip needs more time)

## Root cause

The Safe Apps SDK tests `allowedDomains` regexes against the message `origin`, which is the full origin string including protocol (e.g. `https://app.safe.global`). The `^` anchor caused the regex to never match, so the SDK silently dropped all messages from Safe, making `getInfo()` hang until the timeout.

With a 200ms timeout, `isSafeWallet()` always returned false, completely disabling the safeTxHash resolution introduced in #341.