### PR TITLE
fix: tx status polling

### DIFF
--- a/.changeset/calm-lions-snooze.md
+++ b/.changeset/calm-lions-snooze.md
@@ -1,0 +1,6 @@
+---
+"@aave/client": patch
+"@aave/react": patch
+---
+
+**fix:** use viem client defaults for transaction receipt polling and retries

--- a/packages/client/src/privy.ts
+++ b/packages/client/src/privy.ts
@@ -78,9 +78,6 @@ function sendTransactionAndWait(
       ResultAsync.fromPromise(
         waitForTransactionReceipt(publicClient, {
           hash,
-          pollingInterval: 100,
-          retryCount: 20,
-          retryDelay: 50,
         }),
         (err) => UnexpectedError.from(err),
       ),

--- a/packages/client/src/viem.ts
+++ b/packages/client/src/viem.ts
@@ -288,9 +288,6 @@ export function waitForTransactionResult(
     ResultAsync.fromPromise(
       waitForTransactionReceipt(walletClient, {
         hash: resolvedHash,
-        pollingInterval: 100,
-        retryCount: 20,
-        retryDelay: 50,
       }),
       (err) => UnexpectedError.from(err),
     ).andThen((receipt) => {


### PR DESCRIPTION
Uses the client defaults for viem's `waitForTransactionReceipt`