### PR TITLE
feat(client): add EIP-7702 wallet classification helper for CoW signing

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -9,3 +9,4 @@ export * from './environments';
 export * from './options';
 export type * from './types';
 export { transactionReceipt } from './types';
+export * from './walletKind';

--- a/packages/client/src/walletKind.ts
+++ b/packages/client/src/walletKind.ts
@@ -1,0 +1,104 @@
+/**
+ * On-chain classification of an account, from CoW's signing-scheme
+ * perspective. Drives the choice between EIP-712 (raw ECDSA), EIP-1271
+ * off-chain (raw wallet bytes), and on-chain pre-signature.
+ *
+ * Vendored from the cow-sdk proposal at
+ * https://github.com/cowprotocol/cow-sdk/pull/878. When that ships in a
+ * cow-sdk release, replace `classifyWallet` with the upstream
+ * `classifyAccount` import.
+ *
+ * - `eoa`                    — empty code at the address.
+ * - `delegated-eoa-plain`    — EIP-7702 marker (`0xef0100 || delegate`)
+ *                              whose delegate is NOT in the wrapping
+ *                              registry. Sign EIP-712 normally; the
+ *                              delegate returns raw ECDSA from
+ *                              `signTypedData_v4` that ecrecovers to the
+ *                              EOA address.
+ * - `delegated-eoa-wrapping` — EIP-7702 marker whose delegate IS in the
+ *                              wrapping registry. `signTypedData_v4`
+ *                              returns wrapped bytes (ERC-7739 nested
+ *                              typed data, ERC-7579 MA v2 validator
+ *                              prefix, or both). Forward the bytes
+ *                              verbatim to the backend via the
+ *                              `signatureBytes` input field; the backend
+ *                              tags the order as `eip1271` so CoW resolves
+ *                              verification via `isValidSignature` on the
+ *                              EOA, which EIP-7702 dispatches to the
+ *                              delegate.
+ * - `contract`               — non-trivial code (Safe, custom AA wallet).
+ *                              Use the transaction (presign) path.
+ */
+export type WalletKind =
+  | 'eoa'
+  | 'delegated-eoa-plain'
+  | 'delegated-eoa-wrapping'
+  | 'contract';
+
+/**
+ * Reads the on-chain bytecode at an address. The function shape lets
+ * callers adapt their provider library without us picking sides:
+ *
+ * - ethers v5/v6: `(addr) => provider.getCode(addr)`
+ * - viem:        `(addr) => publicClient.getCode({ address: addr as `0x${string}` })`
+ */
+export type GetCodeFn = (address: string) => Promise<string | null | undefined>;
+
+const EIP7702_DELEGATION_PREFIX = '0xef0100';
+const EIP7702_DELEGATION_HEX_LENGTH = 2 + 23 * 2; // "0x" + 23 bytes
+
+/**
+ * Delegate addresses (lowercase, no `0x`) known to force signature wrapping
+ * at `signTypedData_v4` time. Empty today — populate as wrapping delegates
+ * are confirmed in production (Alchemy Modular Account v2, ZeroDev Kernel
+ * v3, Biconomy Nexus, Safe-via-7702 with 7579 modules, etc.).
+ */
+const WRAPPING_DELEGATES = new Set<string>();
+
+function normalizeDelegateAddress(address: string): string {
+  const lower = address.toLowerCase();
+  return lower.startsWith('0x') ? lower.slice(2) : lower;
+}
+
+function isEip7702DelegationCode(code: string): boolean {
+  const lower = code.toLowerCase();
+  return (
+    lower.length === EIP7702_DELEGATION_HEX_LENGTH &&
+    lower.startsWith(EIP7702_DELEGATION_PREFIX)
+  );
+}
+
+function extractEip7702Delegate(code: string): string | null {
+  if (!isEip7702DelegationCode(code)) return null;
+  return code.slice(2 + 6).toLowerCase();
+}
+
+/**
+ * Classify an account by inspecting on-chain code. Reads `getCode(owner)`
+ * once; callers should cache the result if they need to (no caching here).
+ */
+export async function classifyWallet(
+  getCode: GetCodeFn,
+  owner: string,
+): Promise<WalletKind> {
+  const code = (await getCode(owner)) ?? '0x';
+  if (code === '0x') return 'eoa';
+
+  const delegate = extractEip7702Delegate(code);
+  if (delegate !== null) {
+    return WRAPPING_DELEGATES.has(delegate)
+      ? 'delegated-eoa-wrapping'
+      : 'delegated-eoa-plain';
+  }
+  return 'contract';
+}
+
+/**
+ * Add a delegate address to the wrapping registry at runtime. Useful for
+ * SDK consumers that want to opt a known-wrapping delegate into the
+ * eip1271 path before the static allowlist is updated. Tolerates checksum
+ * casing and `0x` prefix.
+ */
+export function registerWrappingDelegate(address: string): void {
+  WRAPPING_DELEGATES.add(normalizeDelegateAddress(address));
+}


### PR DESCRIPTION
## Summary

Adds `classifyWallet`, `registerWrappingDelegate`, and the `WalletKind` / `GetCodeFn` types to `@aave/client`. These are the building blocks consumers will use to pick between three CoW signing paths once the broader EIP-7702 wrapping-delegate support lands across the stack:

- `eoa` / `delegated-eoa-plain` -> EIP-712 (raw ECDSA)
- `delegated-eoa-wrapping` -> EIP-1271 off-chain with raw wallet bytes
- `contract` -> on-chain pre-signature

The wrapping-delegate registry starts empty; `registerWrappingDelegate(address)` opts in known wrapping delegates at runtime (Alchemy MA v2, ZeroDev Kernel v3, Biconomy Nexus, etc.). Without entries, every 7702 marker resolves to `delegated-eoa-plain` and the existing EIP-712 path is used — production behavior unchanged.

## API

```ts
import { classifyWallet, registerWrappingDelegate, GetCodeFn } from '@aave/client';

// ethers v5/v6
const kind = await classifyWallet((addr) => provider.getCode(addr), owner);

// viem
const kind = await classifyWallet(
  (addr) => publicClient.getCode({ address: addr as `0x${string}` }),
  owner,
);

// Opt in a known wrapping delegate at runtime
registerWrappingDelegate('0x...');
```

`GetCodeFn` is intentionally a plain function shape rather than a provider abstraction; ethers and viem expose different `getCode` parameter shapes, and a one-line lambda at the call site avoids us picking a side.

## Why ship the helper alone

The companion schema change — adding `signatureBytes: String` to `SwapByIntentInput` and making `signature: Signature!` optional — lives in [aave/aave-backend-monorepo#614](https://github.com/aave/aave-backend-monorepo/pull/614). Once that ships and the v4-sdk regenerates its gql-tada turbo cache against the updated schema (`pnpm gql:turbo`), a follow-up PR can plumb `signatureBytes` through the swap action. Shipping the classification helper now lets SDK consumers start integrating ahead of the schema sync.

Vendored from the cow-sdk proposal at [cowprotocol/cow-sdk#878](https://github.com/cowprotocol/cow-sdk/pull/878) — when that releases, swap to the upstream `classifyAccount` import.

## Cross-repo coordination

- cow-sdk: [cowprotocol/cow-sdk#878](https://github.com/cowprotocol/cow-sdk/pull/878) — canonical detection helper.
- aave-backend: [aave/aave-backend-monorepo#614](https://github.com/aave/aave-backend-monorepo/pull/614) — backend classification, eip1271 routing, `signatureBytes` schema field.
- interface-v3: [aave/interface#2984](https://github.com/aave/interface/pull/2984) — three-way wallet branching with vendored helpers.

## Backwards compatibility

- New module + a single re-export line. No existing types, functions, or call sites modified.
- Empty wrapping registry means every classification call resolves to `eoa`, `delegated-eoa-plain`, or `contract` today. No behavioral change.
- No new dependencies; uses standard TypeScript and the plain `Promise<string>` shape.

## Codex backwards-compat review

- Medium (resolved): initial `CodeReader` interface used the ethers-style `getCode(address)` shape which doesn't match viem's `getCode({ address })`. Replaced with a `GetCodeFn` function type that callers adapt to their provider library in one line.
- Verified: no export-name collisions across `@aave/core`, `@aave/graphql`, `@aave/types`, or other client re-exports.
- Verified: EIP-7702 detection matches the spec (`0xef0100 || delegate`, 23 bytes total).
- Verified: `registerWrappingDelegate` only mutates a module-private Set; calling it has no effect on existing call sites that don't use `classifyWallet`.

## Verification

- `./node_modules/.bin/tsc --noEmit` (client package): clean for files in this diff
- `./node_modules/.bin/biome check`: clean after format

Related Linear: SDK-823.