### PR TITLE
fix: remove broken `npm install -g npm@latest` from CI setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,10 +13,6 @@ runs:
         node-version-file: '.nvmrc'
         cache: 'pnpm'
 
-    - name: Update npm
-      shell: bash
-      run: npm install -g npm@latest
-
     - name: Install Dependencies
       shell: bash
       run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Remove the `Update npm` step entirely. Nothing in CI uses npm — install and publish both go through **pnpm** (`pnpm install --frozen-lockfile`, `pnpm publish:results`). The step provided no value and was a recurring source of breakage