### PR TITLE
fix: use recent timestamp in useNetworkFee activity test

### DIFF
--- a/packages/react/src/viem/useNetworkFee.test.ts
+++ b/packages/react/src/viem/useNetworkFee.test.ts
@@ -27,10 +27,6 @@ describe(`Given the ${useNetworkFee.name} hook for Viem/Wagmi integrations`, () 
     const activity: SupplyActivity = {
       __typename: 'SupplyActivity',
       id: '0x123-supply-1' as ID,
-      // Use a recent timestamp: the exchange-rate lookup resolves the rate `at`
-      // this time, and a hard-coded past date eventually drifts outside the
-      // backend's historical price window (fails with "Could not convert
-      // exchange rate").
       timestamp: new Date(),
       txHash: txHash(
         // the first ERC-20 token creation tx

--- a/packages/react/src/viem/useNetworkFee.test.ts
+++ b/packages/react/src/viem/useNetworkFee.test.ts
@@ -27,7 +27,11 @@ describe(`Given the ${useNetworkFee.name} hook for Viem/Wagmi integrations`, () 
     const activity: SupplyActivity = {
       __typename: 'SupplyActivity',
       id: '0x123-supply-1' as ID,
-      timestamp: new Date('2025-10-20T12:00:00Z'),
+      // Use a recent timestamp: the exchange-rate lookup resolves the rate `at`
+      // this time, and a hard-coded past date eventually drifts outside the
+      // backend's historical price window (fails with "Could not convert
+      // exchange rate").
+      timestamp: new Date(),
       txHash: txHash(
         // the first ERC-20 token creation tx
         '0x9e7b5966b33b4393f250bfcf45eed7751d44981b6d8dec9422a0bd2a2c698306',


### PR DESCRIPTION
Use a recent timestamp (`new Date()`) so the exchange-rate lookup stays within range, previous timestamp wasn't working with current devnet