### PR TITLE
chore: raise cache test setup timeout above two indexing waits

### DIFF
--- a/packages/client/src/cache.test.ts
+++ b/packages/client/src/cache.test.ts
@@ -288,7 +288,8 @@ describe('Given the Aave SDK normalized graph cache', () => {
         );
 
       assertOk(setup);
-    }, 60_000);
+      // Two sequential `waitForTransaction` calls, each allowed `indexingTimeout` (60s).
+    }, 150_000);
 
     it('Then it should leverage cached data whenever possible', async () => {
       const primed = await activities(client, {


### PR DESCRIPTION
The `beforeAll` in `cache.test.ts` intermittently fails CI with `Hook timed out in 60000ms`.

`client.waitForTransaction` doesn't wait on the chain — it polls the Aave API until the indexer has processed the tx, bounded by `indexingTimeout` (60s in every environment). The hook awaits it twice sequentially, so its 60s budget equalled a *single* indexing wait, with a `reserves` fetch and a funding tx on top. Zero headroom by construction.

Raises the hook timeout to 150s, above `2 × indexingTimeout` plus setup. This also lets the SDK's own `TimeoutError` (which names the stuck tx hash) win the race, instead of vitest's generic hook message masking it.