### PR TITLE
fix: pin npm@11 in release publish jobs for OIDC trusted publishing

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,6 +13,12 @@ runs:
         node-version-file: '.nvmrc'
         cache: 'pnpm'
 
+    # `changeset publish` shells out to `npm publish`, and OIDC trusted
+    # publishing needs npm >= 11.5.1 (Node 22 bundles npm 10.x).
+    - name: Update npm
+      shell: bash
+      run: npm install -g npm@11
+
     - name: Install Dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,6 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      # `changeset publish` shells out to `npm publish`, and OIDC trusted
-      # publishing needs npm >= 11.5.1 (Node 22 bundles npm 10.x).
-      - name: Update npm
-        run: npm install -g npm@11
-
       - name: Run Changesets
         uses: changesets/action@v1
         with:
@@ -73,11 +68,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
-
-      # `changeset publish` shells out to `npm publish`, and OIDC trusted
-      # publishing needs npm >= 11.5.1 (Node 22 bundles npm 10.x).
-      - name: Update npm
-        run: npm install -g npm@11
 
       - name: Version packages (snapshot)
         run: pnpm changeset version --snapshot ${{ github.event.inputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      # `changeset publish` shells out to `npm publish`, and OIDC trusted
+      # publishing needs npm >= 11.5.1 (Node 22 bundles npm 10.x).
+      - name: Update npm
+        run: npm install -g npm@11
+
       - name: Run Changesets
         uses: changesets/action@v1
         with:
@@ -68,6 +73,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org'
+
+      # `changeset publish` shells out to `npm publish`, and OIDC trusted
+      # publishing needs npm >= 11.5.1 (Node 22 bundles npm 10.x).
+      - name: Update npm
+        run: npm install -g npm@11
 
       - name: Version packages (snapshot)
         run: pnpm changeset version --snapshot ${{ github.event.inputs.tag }}


### PR DESCRIPTION
## Problem

Snapshot releases have failed since #400 with `E404 Not Found - PUT https://registry.npmjs.org/@aave%2f...` for every package (e.g. [this run](https://github.com/aave/aave-v4-sdk/actions/runs/29364126100/job/87191331759)). For scoped packages npm returns 404 on publish when the request is unauthenticated.

## Root cause

Publishing relies on npm OIDC trusted publishing (`id-token: write` + `--provenance`) — there is no `NPM_TOKEN`. Trusted publishing requires npm >= 11.5.1, but Node 22.17.0 (from `.nvmrc`) bundles npm 10.9.x. The `npm install -g npm@latest` step removed in #400 is what had been providing an OIDC-capable npm; its removal assumed npm was unused in CI, but `changeset publish` shells out to `npm publish` under the hood.

## Fix

Restore the npm update step in the shared setup action, pinned to `npm@11` instead of `latest`. Pinning to major 11 avoids both #400 breakages (npm 12.0.1's Node `^22.22.2` engine requirement and its broken self-install) while still supporting OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)