### PR TITLE
fix: drop unsupported --provenance flag from snapshot publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,5 +76,5 @@ jobs:
         run: pnpm build
 
       - name: Publish snapshot
-        run: pnpm changeset publish --tag ${{ github.event.inputs.tag }} --provenance
+        run: pnpm changeset publish --tag ${{ github.event.inputs.tag }}
 


### PR DESCRIPTION
## Problem

Snapshot dispatches fail on `changeset publish` with:

```
🦋  error Unknown flag for publish: --provenance
🦋  error Usage: changeset publish [--tag <name>] [--otp <code>] [--no-git-tag]
```

`--provenance` was never a real changesets flag — older CLI versions silently ignored unknown flags, and `@changesets/cli` 2.31.0 added strict flag validation.

## Fix

Drop the flag. Publishing uses npm OIDC trusted publishing (npm >= 11.5.1 via #404), which generates provenance attestations by default — no flag or config needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)