### PR TITLE
test: fix focused viem and swap scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:client:viem": "vitest --project client packages/client/src/viem.test.ts",
     "test:client": "vitest --project client",
     "test:core": "vitest --project core",
-    "test:react:swap": "vitest --project react packages/react/src/swap.test.ts",
+    "test:react:swap": "vitest --project react packages/react/src/swap/*.test.ts",
     "test:react:viem": "vitest --project react packages/react/src/viem/*.test.ts",
     "test:react": "vitest --project react",
     "test:types": "vitest --project types",

--- a/packages/client/src/viem.test.ts
+++ b/packages/client/src/viem.test.ts
@@ -1,0 +1,70 @@
+import type { Chain } from '@aave/graphql';
+import { tokenInfoId } from '@aave/graphql';
+import { chainId, evmAddress } from '@aave/types';
+import { mainnet } from 'viem/chains';
+import { describe, expect, it } from 'vitest';
+import { toViemChain } from './viem';
+
+const tokenInfo = {
+  __typename: 'TokenInfo',
+  id: tokenInfoId('native-token'),
+  name: 'Ether',
+  symbol: 'ETH',
+  canonicalSymbol: 'ETH',
+  icon: 'https://example.com/eth.svg',
+  decimals: 18,
+  categories: [],
+} satisfies Chain['nativeInfo'];
+
+describe(`Given the ${toViemChain.name} helper`, () => {
+  it('Then it should reuse the known viem mainnet chain definition', () => {
+    const result = toViemChain({
+      chainId: chainId(mainnet.id),
+    } as Chain);
+
+    expect(result).toBe(mainnet);
+  });
+
+  it('Then it should define a viem chain from custom Aave chain metadata', () => {
+    const result = toViemChain({
+      __typename: 'Chain',
+      name: 'Aave Fork',
+      icon: 'https://example.com/fork.svg',
+      chainId: chainId(30303),
+      explorerUrl: 'https://explorer.example.com',
+      isTestnet: true,
+      isFork: true,
+      nativeWrappedToken: evmAddress(
+        '0x0000000000000000000000000000000000000001',
+      ),
+      nativeGateway: evmAddress('0x0000000000000000000000000000000000000002'),
+      signatureGateway: evmAddress(
+        '0x0000000000000000000000000000000000000003',
+      ),
+      nativeWrappedInfo: tokenInfo,
+      nativeInfo: tokenInfo,
+      rpcUrl: 'https://rpc.example.com',
+    });
+
+    expect(result).toMatchObject({
+      id: 30303,
+      name: 'Aave Fork',
+      nativeCurrency: {
+        name: 'Ether',
+        symbol: 'ETH',
+        decimals: 18,
+      },
+      rpcUrls: {
+        default: {
+          http: ['https://rpc.example.com'],
+        },
+      },
+      blockExplorers: {
+        default: {
+          name: 'Aave Fork Explorer',
+          url: 'https://explorer.example.com',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add focused `@aave/client` viem tests for `toViemChain` known-chain reuse and custom chain mapping.
- Fix `test:react:swap` so it targets the existing swap test files instead of the missing `packages/react/src/swap.test.ts` path.

## Why
The repo exposes focused package scripts for contributors, but `test:react:swap` pointed at a file that no longer exists. `test:client:viem` also pointed at a missing test file, so this adds focused coverage for the viem chain conversion helper.

## Validation
- `pnpm lint`
- `pnpm test:client:viem --run`
- `pnpm --filter client build`

I also ran `pnpm test:react:swap --run`; after the path fix it reaches the real swap suites, but local execution fails at import time because `ETHEREUM_TENDERLY_FORK_ID` is not configured and `packages/client/src/testing.ts` constructs `chainId(NaN)`.