### PR TITLE
fix: clarify Tenderly test env requirements

### DIFF
--- a/.changeset/calm-forks-warn.md
+++ b/.changeset/calm-forks-warn.md
@@ -1,0 +1,5 @@
+---
+"@aave/client": patch
+---
+
+**fix:** clarify missing Tenderly fork test environment variables

--- a/packages/client/src/testing.ts
+++ b/packages/client/src/testing.ts
@@ -43,8 +43,27 @@ export const environment =
       ? production
       : staging;
 
+function requiredEnv(name: keyof ImportMetaEnv): string {
+  const value = import.meta.env[name];
+  invariant(
+    value,
+    `Missing ${name}. Copy .env.example to .env and configure the Tenderly fork settings before running fork-backed tests.`,
+  );
+  return value;
+}
+
+function requiredIntegerEnv(name: keyof ImportMetaEnv): number {
+  const raw = requiredEnv(name);
+  const value = Number.parseInt(raw, 10);
+  invariant(
+    Number.isInteger(value) && value >= 0,
+    `${name} must be a non-negative integer. Received: ${raw}`,
+  );
+  return value;
+}
+
 export const ETHEREUM_FORK_ID = chainId(
-  Number.parseInt(import.meta.env.ETHEREUM_TENDERLY_FORK_ID, 10),
+  requiredIntegerEnv('ETHEREUM_TENDERLY_FORK_ID'),
 );
 
 // Token addresses
@@ -113,11 +132,13 @@ export const ETHEREUM_HUB_CORE_ID = encodeHubId({
   address: ETHEREUM_HUB_CORE_ADDRESS,
 });
 
-export const ETHEREUM_FORK_RPC_URL = import.meta.env
-  .ETHEREUM_TENDERLY_PUBLIC_RPC;
+export const ETHEREUM_FORK_RPC_URL = requiredEnv(
+  'ETHEREUM_TENDERLY_PUBLIC_RPC',
+);
 
-export const ETHEREUM_FORK_RPC_URL_ADMIN = import.meta.env
-  .ETHEREUM_TENDERLY_ADMIN_RPC;
+export const ETHEREUM_FORK_RPC_URL_ADMIN = requiredEnv(
+  'ETHEREUM_TENDERLY_ADMIN_RPC',
+);
 
 export const client = AaveClient.create({
   environment,


### PR DESCRIPTION
## Summary
- validate required Tenderly fork environment variables before constructing fork-backed test constants
- replace the previous `Invalid ChainId: NaN` failure path with actionable messages that name the missing or invalid env var
- add a patch changeset for `@aave/client`

## Validation
- `pnpm lint`
- `pnpm --filter client build`
- `pnpm vitest --project react packages/react/src/swap/*.test.ts --run` now fails early with `Missing ETHEREUM_TENDERLY_FORK_ID...` in this environment because Tenderly fork secrets are not configured