### PR TITLE
docs: add Safe App React example

### DIFF
--- a/examples/react-safe/README.md
+++ b/examples/react-safe/README.md
@@ -1,0 +1,21 @@
+# Aave React SDK + Safe App
+
+Small Safe App example that supplies GHO on Ethereum mainnet with `@aave/react`.
+
+## Run locally
+
+```bash
+pnpm install --ignore-workspace --no-lockfile
+pnpm dev
+```
+
+Then open Safe, go to Apps, add a custom app, and enter your local Vite URL.
+The Safe must be on Ethereum mainnet because the example filters reserves by
+GHO on chain `1`.
+
+The example shows how to:
+
+- read Safe context with `@safe-global/safe-apps-sdk`
+- expose the Safe as a viem wallet client through a small EIP-1193 adapter
+- use `@aave/react` hooks inside a Safe App
+- queue approval and supply transactions through Safe

--- a/examples/react-safe/index.html
+++ b/examples/react-safe/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Aave React SDK + Safe App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-safe/package.json
+++ b/examples/react-safe/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "react-safe",
+  "description": "Aave React SDK + Safe App",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build"
+  },
+  "dependencies": {
+    "@aave/react": "next",
+    "@safe-global/safe-apps-sdk": "^9.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "viem": "^2.47.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react-swc": "^3.7.2",
+    "typescript": "^5.6.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/react-safe/src/App.tsx
+++ b/examples/react-safe/src/App.tsx
@@ -1,0 +1,59 @@
+import { Suspense } from 'react';
+import type { Address } from 'viem';
+import { mainnet } from 'viem/chains';
+import { SupplyForm } from './SupplyForm';
+import { useSafeWallet } from './safeWallet';
+
+export function App() {
+  const { error, loading, safe, walletClient } = useSafeWallet();
+
+  if (loading) {
+    return <main>Loading Safe context...</main>;
+  }
+
+  if (error || !safe || !walletClient) {
+    return (
+      <main>
+        <h1>Aave React SDK + Safe App</h1>
+        <p>Open this app from the Safe Apps iframe to connect a Safe.</p>
+        {error && <p role='alert'>{error}</p>}
+      </main>
+    );
+  }
+
+  if (safe.chainId !== mainnet.id) {
+    return (
+      <main>
+        <h1>Aave React SDK + Safe App</h1>
+        <p>Switch your Safe to Ethereum mainnet before supplying GHO.</p>
+        <dl>
+          <dt>Safe</dt>
+          <dd>{safe.safeAddress}</dd>
+          <dt>Connected chain</dt>
+          <dd>{safe.chainId}</dd>
+        </dl>
+      </main>
+    );
+  }
+
+  return (
+    <Suspense fallback={<main>Loading Aave data...</main>}>
+      <main>
+        <header>
+          <h1>Aave React SDK + Safe App</h1>
+          <dl>
+            <dt>Safe</dt>
+            <dd>{safe.safeAddress}</dd>
+            <dt>Chain</dt>
+            <dd>Ethereum mainnet</dd>
+          </dl>
+        </header>
+
+        <SupplyForm
+          safeAddress={safe.safeAddress as Address}
+          walletClient={walletClient}
+        />
+      </main>
+    </Suspense>
+  );
+}

--- a/examples/react-safe/src/SupplyForm.tsx
+++ b/examples/react-safe/src/SupplyForm.tsx
@@ -1,0 +1,165 @@
+import {
+  bigDecimal,
+  chainId,
+  evmAddress,
+  ReservesRequestFilter,
+  useReserves,
+  useSupply,
+} from '@aave/react';
+import { useSendTransaction } from '@aave/react/viem';
+import { useMemo, useState } from 'react';
+import type { Address, WalletClient } from 'viem';
+import { mainnet } from 'viem/chains';
+
+type StatusKind = 'info' | 'success' | 'error';
+
+interface SupplyFormProps {
+  safeAddress: Address;
+  walletClient: WalletClient;
+}
+
+export function SupplyForm({ safeAddress, walletClient }: SupplyFormProps) {
+  const [status, setStatus] = useState<{
+    kind: StatusKind;
+    message: string;
+  } | null>(null);
+
+  const {
+    data: reserves,
+    error: reservesError,
+    loading: loadingReserves,
+  } = useReserves({
+    query: {
+      chainIds: [chainId(mainnet.id)],
+    },
+    filter: ReservesRequestFilter.Supply,
+    user: evmAddress(safeAddress),
+  });
+
+  const reserve = useMemo(
+    () =>
+      reserves?.find(
+        (item) =>
+          item.asset.underlying.info.symbol === 'GHO' &&
+          item.canSupply &&
+          item.status.active &&
+          !item.status.frozen &&
+          !item.status.paused,
+      ),
+    [reserves],
+  );
+
+  const [sendTransaction] = useSendTransaction(walletClient);
+  const [supply, { loading, error }] = useSupply((plan) => {
+    switch (plan.__typename) {
+      case 'TransactionRequest':
+        setStatus({ kind: 'info', message: 'Queue the supply transaction.' });
+        return sendTransaction(plan).andTee(() =>
+          setStatus({
+            kind: 'info',
+            message: 'Supply transaction queued. Waiting for Safe execution.',
+          }),
+        );
+
+      case 'Erc20Approval':
+        setStatus({ kind: 'info', message: 'Queue the ERC-20 approval.' });
+        return sendTransaction(plan.byTransaction).andTee(() =>
+          setStatus({
+            kind: 'info',
+            message: 'Approval queued. Waiting for Safe execution.',
+          }),
+        );
+
+      case 'PreContractActionRequired':
+        setStatus({
+          kind: 'info',
+          message: 'Queue the pre-contract action transaction.',
+        });
+        return sendTransaction(plan.transaction).andTee(() =>
+          setStatus({
+            kind: 'info',
+            message: 'Pre-contract action queued. Waiting for Safe execution.',
+          }),
+        );
+    }
+  });
+
+  const submit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!reserve) {
+      setStatus({ kind: 'error', message: 'No active GHO reserve found.' });
+      return;
+    }
+
+    const amount = event.currentTarget.amount.value as string;
+    if (!amount) {
+      setStatus({ kind: 'info', message: 'Enter an amount first.' });
+      return;
+    }
+
+    const result = await supply({
+      reserve: reserve.id,
+      amount: {
+        erc20: {
+          value: bigDecimal(amount),
+        },
+      },
+      sender: evmAddress(safeAddress),
+    });
+
+    if (result.isErr()) {
+      switch (result.error.name) {
+        case 'ValidationError':
+          setStatus({
+            kind: 'error',
+            message: 'The Safe does not have enough GHO for this supply.',
+          });
+          return;
+        case 'CancelError':
+          setStatus({ kind: 'info', message: 'Safe transaction cancelled.' });
+          return;
+        default:
+          setStatus({ kind: 'error', message: result.error.message });
+          return;
+      }
+    }
+
+    setStatus({
+      kind: 'success',
+      message: `Supply confirmed: ${result.value.txHash}`,
+    });
+  };
+
+  const tokenLabel = reserve
+    ? `${reserve.asset.underlying.info.symbol} on ${reserve.chain.name}`
+    : 'GHO on Ethereum mainnet';
+
+  return (
+    <form onSubmit={submit}>
+      <label>
+        <strong>Reserve</strong>
+        <span>{loadingReserves ? 'Loading reserves...' : tokenLabel}</span>
+      </label>
+
+      <label>
+        <strong>Amount</strong>
+        <input
+          name='amount'
+          type='number'
+          step='0.000000000000000001'
+          disabled={loading || loadingReserves || !reserve}
+          placeholder='Amount to supply'
+        />
+      </label>
+
+      <button type='submit' disabled={loading || loadingReserves || !reserve}>
+        Queue Safe transaction
+      </button>
+
+      {reservesError && <p role='alert'>{reservesError.message}</p>}
+      {error && <p role='alert'>{error.message}</p>}
+      {status && <p data-kind={status.kind}>{status.message}</p>}
+    </form>
+  );
+}

--- a/examples/react-safe/src/client.ts
+++ b/examples/react-safe/src/client.ts
@@ -1,0 +1,5 @@
+import { AaveClient, production } from '@aave/react';
+
+export const client = AaveClient.create({
+  environment: production,
+});

--- a/examples/react-safe/src/main.tsx
+++ b/examples/react-safe/src/main.tsx
@@ -1,0 +1,11 @@
+import { AaveProvider } from '@aave/react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import { client } from './client';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <AaveProvider client={client}>
+    <App />
+  </AaveProvider>,
+);

--- a/examples/react-safe/src/safeWallet.ts
+++ b/examples/react-safe/src/safeWallet.ts
@@ -1,0 +1,212 @@
+import SafeAppsSDK, {
+  type BaseTransaction,
+  type SafeInfo,
+} from '@safe-global/safe-apps-sdk';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  type Address,
+  createWalletClient,
+  custom,
+  type EIP1193Provider,
+  type Hex,
+  numberToHex,
+  type WalletClient,
+} from 'viem';
+import { mainnet } from 'viem/chains';
+
+const SAFE_INFO_TIMEOUT_MS = 5000;
+
+type SafeWalletState = {
+  error: string | null;
+  loading: boolean;
+  safe: SafeInfo | null;
+  walletClient: WalletClient | null;
+};
+
+type RpcTransaction = {
+  data?: Hex;
+  to?: Address;
+  value?: string;
+};
+
+function firstParam(params: unknown): unknown {
+  return Array.isArray(params) ? params[0] : undefined;
+}
+
+function firstStringParam(params: unknown): string {
+  const value = firstParam(params);
+  if (typeof value !== 'string') {
+    throw new Error('Expected the first RPC parameter to be a string.');
+  }
+  return value;
+}
+
+function transactionFrom(params: unknown): BaseTransaction {
+  const value = firstParam(params);
+  if (!value || typeof value !== 'object') {
+    throw new Error('Expected an RPC transaction object.');
+  }
+
+  const transaction = value as RpcTransaction;
+  if (!transaction.to) {
+    throw new Error('Safe transactions require a recipient address.');
+  }
+
+  return {
+    to: transaction.to,
+    value: transaction.value ?? '0',
+    data: transaction.data ?? '0x',
+  };
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(
+        () => reject(new Error('Timed out while reading Safe context.')),
+        timeoutMs,
+      ),
+    ),
+  ]);
+}
+
+function createSafeProvider(sdk: SafeAppsSDK, safe: SafeInfo): EIP1193Provider {
+  const chainHex = numberToHex(safe.chainId);
+
+  return {
+    request: async ({ method, params }) => {
+      switch (method) {
+        case 'eth_accounts':
+        case 'eth_requestAccounts':
+          return [safe.safeAddress];
+
+        case 'eth_chainId':
+          return chainHex;
+
+        case 'net_version':
+          return String(safe.chainId);
+
+        case 'eth_sendTransaction': {
+          const tx = await sdk.txs.send({
+            txs: [transactionFrom(params)],
+          });
+          return tx.safeTxHash;
+        }
+
+        case 'eth_estimateGas': {
+          const tx = transactionFrom(params);
+          const gas = await sdk.eth.getEstimateGas({
+            from: safe.safeAddress,
+            to: tx.to,
+            value: tx.value,
+            data: tx.data,
+          });
+          return numberToHex(gas);
+        }
+
+        case 'eth_call':
+          return sdk.eth.call(params as Parameters<typeof sdk.eth.call>[0]);
+
+        case 'eth_getBalance':
+          return sdk.eth.getBalance(
+            params as Parameters<typeof sdk.eth.getBalance>[0],
+          );
+
+        case 'eth_getCode':
+          return sdk.eth.getCode(
+            params as Parameters<typeof sdk.eth.getCode>[0],
+          );
+
+        case 'eth_getStorageAt':
+          return sdk.eth.getStorageAt(
+            params as Parameters<typeof sdk.eth.getStorageAt>[0],
+          );
+
+        case 'eth_getLogs':
+          return sdk.eth.getPastLogs(
+            params as Parameters<typeof sdk.eth.getPastLogs>[0],
+          );
+
+        case 'eth_getBlockByHash':
+          return sdk.eth.getBlockByHash(
+            params as Parameters<typeof sdk.eth.getBlockByHash>[0],
+          );
+
+        case 'eth_getBlockByNumber':
+          return sdk.eth.getBlockByNumber(
+            params as Parameters<typeof sdk.eth.getBlockByNumber>[0],
+          );
+
+        case 'eth_getTransactionByHash':
+          return sdk.eth.getTransactionByHash([firstStringParam(params)]);
+
+        case 'eth_getTransactionReceipt':
+          return sdk.eth.getTransactionReceipt([firstStringParam(params)]);
+
+        case 'eth_getTransactionCount':
+          return sdk.eth.getTransactionCount(
+            params as Parameters<typeof sdk.eth.getTransactionCount>[0],
+          );
+
+        case 'eth_gasPrice':
+          return sdk.eth.getGasPrice();
+
+        default:
+          throw new Error(`Unsupported Safe RPC method: ${method}`);
+      }
+    },
+  } as EIP1193Provider;
+}
+
+function createSafeWalletClient(
+  sdk: SafeAppsSDK,
+  safe: SafeInfo,
+): WalletClient {
+  return createWalletClient({
+    account: safe.safeAddress as Address,
+    chain: mainnet,
+    transport: custom(createSafeProvider(sdk, safe)),
+  });
+}
+
+export function useSafeWallet(): SafeWalletState {
+  const sdk = useMemo(() => new SafeAppsSDK(), []);
+  const [state, setState] = useState<SafeWalletState>({
+    error: null,
+    loading: true,
+    safe: null,
+    walletClient: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    withTimeout(sdk.safe.getInfo(), SAFE_INFO_TIMEOUT_MS)
+      .then((safe) => {
+        if (cancelled) return;
+        setState({
+          error: null,
+          loading: false,
+          safe,
+          walletClient: createSafeWalletClient(sdk, safe),
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({
+          error: message,
+          loading: false,
+          safe: null,
+          walletClient: null,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sdk]);
+
+  return state;
+}

--- a/examples/react-safe/src/styles.css
+++ b/examples/react-safe/src/styles.css
@@ -1,0 +1,93 @@
+body {
+  margin: 0;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: #1f2937;
+  background: #f7f8fb;
+}
+
+main {
+  width: min(720px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 32px 0;
+}
+
+header {
+  margin-bottom: 24px;
+}
+
+h1 {
+  margin: 0 0 16px;
+  font-size: 28px;
+  line-height: 1.2;
+}
+
+dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 16px;
+  margin: 0;
+}
+
+dt {
+  color: #6b7280;
+}
+
+dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+form {
+  display: grid;
+  gap: 16px;
+  padding: 24px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fff;
+}
+
+label {
+  display: grid;
+  gap: 8px;
+}
+
+input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font: inherit;
+}
+
+button {
+  width: max-content;
+  min-height: 40px;
+  padding: 0 16px;
+  border: 0;
+  border-radius: 6px;
+  font: inherit;
+  color: #fff;
+  background: #2563eb;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+p {
+  margin: 0;
+}
+
+p[role="alert"],
+p[data-kind="error"] {
+  color: #b91c1c;
+}
+
+p[data-kind="success"] {
+  color: #047857;
+}

--- a/examples/react-safe/src/vite-env.d.ts
+++ b/examples/react-safe/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/react-safe/tsconfig.json
+++ b/examples/react-safe/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/react-safe/vite.config.ts
+++ b/examples/react-safe/vite.config.ts
@@ -1,0 +1,6 @@
+import react from '@vitejs/plugin-react-swc';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- Add a standalone `examples/react-safe` Vite app for running `@aave/react` inside a Safe App iframe.
- Read Safe context with `@safe-global/safe-apps-sdk` and expose the Safe through a small EIP-1193 adapter-backed viem wallet client.
- Demonstrate a mainnet GHO supply flow with `useReserves`, `useSupply`, and `useSendTransaction`, including Safe approval/supply queueing states.
- Document local Safe custom-app setup and the `pnpm install --ignore-workspace --no-lockfile` command needed for this standalone example inside the monorepo.

Fixes #379

## Validation
- `pnpm biome check --write examples/react-safe`
- `pnpm -C examples/react-safe build`
- `pnpm lint`
- `pnpm --filter @aave/react build`