### PR TITLE
test: add example build workflow

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,83 @@
+name: Examples
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/examples.yml'
+      - 'examples/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  discover:
+    name: Discover examples
+    runs-on: ubuntu-latest
+    outputs:
+      examples: ${{ steps.examples.outputs.examples }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: examples
+        name: Find buildable examples
+        shell: bash
+        run: |
+          examples=$(node <<'NODE'
+          const { readdirSync, readFileSync } = require('node:fs');
+          const { join } = require('node:path');
+
+          const examples = readdirSync('examples', { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) => entry.name)
+            .filter((name) => {
+              try {
+                const pkg = JSON.parse(
+                  readFileSync(join('examples', name, 'package.json'), 'utf8'),
+                );
+                return Boolean(pkg.scripts?.build);
+              } catch {
+                return false;
+              }
+            })
+            .sort();
+
+          process.stdout.write(JSON.stringify(examples));
+          NODE
+          )
+          echo "examples=${examples}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.example }}
+    needs: discover
+    if: ${{ needs.discover.outputs.examples != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example: ${{ fromJson(needs.discover.outputs.examples) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install example dependencies
+        shell: bash
+        run: pnpm -C examples/${{ matrix.example }} install --ignore-workspace --no-lockfile
+
+      - name: Build example
+        shell: bash
+        run: pnpm -C examples/${{ matrix.example }} build

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # build output
 **/dist
+examples/*/build
 /docs
 */graphql-cache.d.ts
 

--- a/examples/react-connectkit/package.json
+++ b/examples/react-connectkit/package.json
@@ -5,7 +5,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build"
   },
   "dependencies": {
     "@aave/react": "next",

--- a/examples/react-connectkit/src/SupplyForm.tsx
+++ b/examples/react-connectkit/src/SupplyForm.tsx
@@ -22,7 +22,10 @@ export function SupplyForm({ walletClient }: SupplyFormProps) {
         setStatus('Sending transaction…');
         return sendTransaction(plan);
 
-      case 'Erc20ApprovalRequired':
+      case 'Erc20Approval':
+        setStatus('Approval required. Sending approval transaction…');
+        return sendTransaction(plan.byTransaction);
+
       case 'PreContractActionRequired':
         setStatus('Approval required. Sending approval transaction…');
         return sendTransaction(plan.transaction);

--- a/examples/react-privy/package.json
+++ b/examples/react-privy/package.json
@@ -5,7 +5,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build"
   },
   "dependencies": {
     "@aave/react": "next",

--- a/examples/react-privy/src/SupplyForm.tsx
+++ b/examples/react-privy/src/SupplyForm.tsx
@@ -23,7 +23,12 @@ export function SupplyForm({ wallet }: SupplyFormProps) {
           setStatus('Sending Supply Transaction…'),
         );
 
-      case 'Erc20ApprovalRequired':
+      case 'Erc20Approval':
+        setStatus('Sign the Approval Transaction in your wallet');
+        return sendTransaction(plan.byTransaction).andTee(() =>
+          setStatus('Sending Approval Transaction…'),
+        );
+
       case 'PreContractActionRequired':
         setStatus('Sign the Approval Transaction in your wallet');
         return sendTransaction(plan.transaction).andTee(() =>

--- a/examples/react-stories/package.json
+++ b/examples/react-stories/package.json
@@ -5,7 +5,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "ladle serve"
+    "dev": "ladle serve",
+    "build": "tsc --noEmit && ladle build --viteConfig vite.config.mjs"
   },
   "dependencies": {
     "@aave/client": "next",

--- a/examples/react-stories/src/components/RepayForm.tsx
+++ b/examples/react-stories/src/components/RepayForm.tsx
@@ -41,7 +41,18 @@ export function RepayForm({ borrow, walletClient }: RepayFormProps) {
           }),
         );
 
-      case 'Erc20ApprovalRequired':
+      case 'Erc20Approval':
+        setStatus({
+          kind: KIND.info,
+          message: 'Sign the Approval Transaction in your wallet',
+        });
+        return sendTransaction(plan.byTransaction).andTee(() =>
+          setStatus({
+            kind: KIND.info,
+            message: 'Sending Approval Transaction…',
+          }),
+        );
+
       case 'PreContractActionRequired':
         setStatus({
           kind: KIND.info,

--- a/examples/react-stories/src/components/SupplyForm.tsx
+++ b/examples/react-stories/src/components/SupplyForm.tsx
@@ -34,7 +34,18 @@ export function SupplyForm({ reserve, walletClient }: SupplyFormProps) {
           }),
         );
 
-      case 'Erc20ApprovalRequired':
+      case 'Erc20Approval':
+        setStatus({
+          kind: KIND.info,
+          message: 'Sign the Approval Transaction in your wallet',
+        });
+        return sendTransaction(plan.byTransaction).andTee(() =>
+          setStatus({
+            kind: KIND.info,
+            message: 'Sending Approval Transaction…',
+          }),
+        );
+
       case 'PreContractActionRequired':
         setStatus({
           kind: KIND.info,

--- a/examples/react-stories/src/components/WithdrawForm.tsx
+++ b/examples/react-stories/src/components/WithdrawForm.tsx
@@ -41,7 +41,6 @@ export function WithdrawForm({ supply, walletClient }: WithdrawFormProps) {
           }),
         );
 
-      case 'Erc20ApprovalRequired':
       case 'PreContractActionRequired':
         setStatus({
           kind: KIND.info,

--- a/examples/react-stories/vite.config.mjs
+++ b/examples/react-stories/vite.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  build: {
+    target: 'esnext',
+  },
+};

--- a/examples/react-thirdweb/package.json
+++ b/examples/react-thirdweb/package.json
@@ -5,7 +5,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite"
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build"
   },
   "dependencies": {
     "@aave/react": "next",

--- a/examples/react-thirdweb/src/SupplyForm.tsx
+++ b/examples/react-thirdweb/src/SupplyForm.tsx
@@ -22,7 +22,10 @@ export function SupplyForm({ wallet }: SupplyFormProps) {
         setStatus('Sending transaction…');
         return sendTransaction(plan);
 
-      case 'Erc20ApprovalRequired':
+      case 'Erc20Approval':
+        setStatus('Approval required. Sending approval transaction…');
+        return sendTransaction(plan.byTransaction);
+
       case 'PreContractActionRequired':
         setStatus('Approval required. Sending approval transaction…');
         return sendTransaction(plan.transaction);


### PR DESCRIPTION
## Summary
- Add an `Examples` GitHub Actions workflow that discovers standalone example apps with a `build` script, then installs and builds them in a matrix when examples change.
- Add `build` scripts to the existing React examples so they can be smoke-tested outside the monorepo workspace.
- Update example transaction handlers from the stale `Erc20ApprovalRequired` branch to the current `Erc20Approval` plan shape.
- Add a small Vite config for `react-stories` so its Ladle production build supports the example wallet module's top-level await.

## Validation
- `pnpm lint`
- `pnpm changeset status --since=origin/main`
- local discovery script output: `["react-connectkit","react-privy","react-stories","react-thirdweb"]`
- `pnpm -C examples/react-connectkit install --ignore-workspace --no-lockfile`
- `pnpm -C examples/react-connectkit build`
- `pnpm -C examples/react-privy install --ignore-workspace --no-lockfile`
- `pnpm -C examples/react-privy build`
- `pnpm -C examples/react-thirdweb install --ignore-workspace --no-lockfile`
- `pnpm -C examples/react-thirdweb build`
- `pnpm -C examples/react-stories install --ignore-workspace --no-lockfile`
- `pnpm -C examples/react-stories build`