### PR TITLE
docs: development workflow tells contributors to clone the V3 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This section is for developers who want to contribute to the SDK.
 Clone the repository:
 
 ```bash
-git clone https://github.com/aave/aave-sdk.git
+git clone https://github.com/aave/aave-v4-sdk.git
 ```
 
 Install the dependencies:


### PR DESCRIPTION
## Problem

`README.md:21`, the first step of the Development Workflow:

```shell
git clone https://github.com/aave/aave-sdk.git
```

`aave/aave-sdk` is a different, live repository — its own description is *"The official SDK for Aave V3"*. So a contributor following this repository's own setup instructions ends up in the V3 codebase, and the following steps (install, build, test) run against the wrong project.

## Fix

One line: point it at `aave/aave-v4-sdk`.