### PR TITLE
fix: refresh user-specific position manager cache

### DIFF
--- a/.changeset/quiet-managers-refresh.md
+++ b/.changeset/quiet-managers-refresh.md
@@ -1,0 +1,5 @@
+---
+"@aave/react": patch
+---
+
+**fix:** refresh user-specific position manager queries after approval or revocation

--- a/packages/react/src/helpers/cache.test.ts
+++ b/packages/react/src/helpers/cache.test.ts
@@ -1,0 +1,86 @@
+import { AaveClient } from '@aave/client';
+import { environment } from '@aave/client/testing';
+import {
+  PageSize,
+  SpokeUserPositionManagersQuery,
+  spokeId,
+} from '@aave/graphql';
+import { evmAddress } from '@aave/types';
+import * as msw from 'msw';
+import { setupServer } from 'msw/node';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { refreshSpokePositionManagers } from './cache';
+
+const api = msw.graphql.link(environment.backend);
+const server = setupServer(msw.http.all('*', async () => msw.passthrough()));
+
+const spoke = spokeId('SGVsbG8h');
+const user = evmAddress('0x0000000000000000000000000000000000000001');
+const request = {
+  spoke,
+  user,
+  pageSize: PageSize.Fifty,
+};
+
+describe('refreshSpokePositionManagers', () => {
+  let requestCount = 0;
+
+  beforeAll(() => {
+    server.listen();
+  });
+
+  beforeEach(() => {
+    requestCount = 0;
+    server.use(
+      api.query(SpokeUserPositionManagersQuery, () => {
+        requestCount++;
+        return msw.HttpResponse.json({
+          data: {
+            value: {
+              __typename: 'PaginatedSpokeUserPositionManagerResult',
+              items: [],
+              pageInfo: {
+                __typename: 'PaginatedResultInfo',
+                prev: null,
+                next: null,
+              },
+            },
+          },
+        });
+      }),
+    );
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('refreshes the watched user-specific manager query', async () => {
+    const client = AaveClient.create({ environment });
+    const subscription = client.urql
+      .query(SpokeUserPositionManagersQuery, { request })
+      .subscribe(() => {});
+
+    await vi.waitFor(() => expect(requestCount).toBe(1));
+
+    const result = await refreshSpokePositionManagers(client, spoke, user);
+
+    expect(result.isOk()).toBe(true);
+    await vi.waitFor(() => expect(requestCount).toBe(2));
+
+    subscription.unsubscribe();
+  });
+});

--- a/packages/react/src/helpers/cache.ts
+++ b/packages/react/src/helpers/cache.ts
@@ -20,6 +20,7 @@ import {
   SpokePositionManagersQuery,
   SpokeQuery,
   SpokesQuery,
+  SpokeUserPositionManagersQuery,
   type SupplyRequest,
   UserBalancesQuery,
   UserBorrowsQuery,
@@ -233,11 +234,19 @@ export function refreshHubs(client: AaveClient, chainId: ChainId) {
 export function refreshSpokePositionManagers(
   client: AaveClient,
   spoke: SpokeId,
+  user: EvmAddress,
 ) {
-  return client.refreshQueryWhere(
-    SpokePositionManagersQuery,
-    (variables) => variables.request.spoke === spoke,
-  );
+  return ResultAsync.combine([
+    client.refreshQueryWhere(
+      SpokePositionManagersQuery,
+      (variables) => variables.request.spoke === spoke,
+    ),
+    client.refreshQueryWhere(
+      SpokeUserPositionManagersQuery,
+      (variables) =>
+        variables.request.spoke === spoke && variables.request.user === user,
+    ),
+  ]);
 }
 
 /**

--- a/packages/react/src/transactions/useRenounceSpokeUserPositionManager.ts
+++ b/packages/react/src/transactions/useRenounceSpokeUserPositionManager.ts
@@ -74,7 +74,9 @@ export function useRenounceSpokeUserPositionManager(
         .andThen((transaction) => handler(transaction, { cancel }))
         .andThen((pending) => pending.wait())
         .andThen(client.waitForTransaction)
-        .andThrough(() => refreshSpokePositionManagers(client, request.spoke)),
+        .andThrough(() =>
+          refreshSpokePositionManagers(client, request.spoke, request.managing),
+        ),
     [client, handler],
   );
 }

--- a/packages/react/src/transactions/useSetSpokeUserPositionManager.ts
+++ b/packages/react/src/transactions/useSetSpokeUserPositionManager.ts
@@ -93,7 +93,9 @@ export function useSetSpokeUserPositionManager(
         .andThen((transaction) => handler(transaction, { cancel }))
         .andThen((pending) => pending.wait())
         .andThen(client.waitForTransaction)
-        .andThrough(() => refreshSpokePositionManagers(client, request.spoke)),
+        .andThrough(() =>
+          refreshSpokePositionManagers(client, request.spoke, request.user),
+        ),
     [client, handler],
   );
 }


### PR DESCRIPTION
closes #422 

Refresh `SpokeUserPositionManagersQuery` after successful Position Manager approval or revocation.
