### PR TITLE
fix: coalesce duplicate in-flight query requests

### DIFF
--- a/.changeset/witty-queries-coalesce.md
+++ b/.changeset/witty-queries-coalesce.md
@@ -1,0 +1,7 @@
+---
+"@aave/core": patch
+"@aave/client": patch
+"@aave/react": patch
+---
+
+**fix:** coalesce same-key query operations onto in-flight network requests instead of issuing duplicates, in both the batched (`batchFetchExchange`) and non-batched (`inFlightDedupExchange` + `fetchExchange`) pipelines

--- a/packages/core/src/GqlClient.ts
+++ b/packages/core/src/GqlClient.ts
@@ -22,6 +22,7 @@ import {
 import { map, pipe, tap } from 'wonka';
 import { batchFetchExchange } from './batching';
 import type { Context } from './context';
+import { inFlightDedupExchange, refetching } from './dedup';
 import { UnexpectedError } from './errors';
 import { Logger, LogLevel } from './logger';
 import type { StandardData } from './types';
@@ -40,8 +41,6 @@ export type QueryOptions = {
    */
   batch?: boolean;
 };
-
-const refetching = Symbol('refetching');
 
 export class GqlClient {
   /**
@@ -277,7 +276,9 @@ export class GqlClient {
         }),
       );
     } else {
-      exchanges.push(fetchExchange);
+      // The plain fetch pipeline has no coalescing of its own, so install it
+      // here; `batchFetchExchange` handles this itself for the batched one.
+      exchanges.push(inFlightDedupExchange(), fetchExchange);
     }
 
     return exchanges;

--- a/packages/core/src/batching.test.ts
+++ b/packages/core/src/batching.test.ts
@@ -1,0 +1,249 @@
+import {
+  createRequest,
+  gql,
+  makeOperation,
+  type Operation,
+  type OperationContext,
+  type OperationResult,
+} from '@urql/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  filter,
+  makeSubject,
+  pipe,
+  type Source,
+  type Subscription,
+  subscribe,
+} from 'wonka';
+import { batchFetchExchange } from './batching';
+import { delay } from './utils';
+
+const url = 'https://api.test/graphql';
+
+const QueryA = gql`
+  query A {
+    a
+  }
+`;
+
+const QueryB = gql`
+  query B {
+    b
+  }
+`;
+
+function queryOperation(document: typeof QueryA): Operation {
+  return makeOperation('query', createRequest(document, {}), {
+    url,
+    requestPolicy: 'cache-and-network',
+  } as OperationContext);
+}
+
+function teardownOperation(operation: Operation): Operation {
+  return makeOperation('teardown', operation, operation.context);
+}
+
+type PendingFetch = {
+  body: unknown;
+  resolve: (response: Response) => void;
+  reject: (error: unknown) => void;
+};
+
+describe(`Given the '${batchFetchExchange.name}' exchange`, () => {
+  let pendingFetches: PendingFetch[];
+  let results: OperationResult[];
+  let next: (operation: Operation) => void;
+  let subscription: Subscription;
+
+  beforeEach(() => {
+    pendingFetches = [];
+    results = [];
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_input: unknown, init?: RequestInit) =>
+          new Promise<Response>((resolve, reject) => {
+            pendingFetches.push({
+              body: init?.body ? JSON.parse(init.body as string) : undefined,
+              resolve,
+              reject,
+            });
+          }),
+      ),
+    );
+
+    const subject = makeSubject<Operation>();
+    next = subject.next;
+
+    const exchange = batchFetchExchange({
+      batchInterval: 1,
+      maxBatchSize: 10,
+      url,
+    });
+
+    const io = exchange({
+      forward: (ops$) =>
+        pipe(
+          ops$,
+          filter(() => false),
+        ) as unknown as Source<OperationResult>,
+      client: {} as never,
+      dispatchDebug: () => {},
+    });
+
+    subscription = pipe(
+      io(subject.source),
+      subscribe((result) => results.push(result)),
+    );
+  });
+
+  afterEach(() => {
+    subscription.unsubscribe();
+    vi.unstubAllGlobals();
+  });
+
+  describe('When operations with the same key are dispatched within the same batch window', () => {
+    it('Then the batch carries a single entry for that key and the response fans out to every subscriber', async () => {
+      const opA = queryOperation(QueryA);
+
+      next(opA);
+      next(queryOperation(QueryA)); // same key, same window
+      next(queryOperation(QueryB));
+      await delay(10);
+
+      expect(pendingFetches).toHaveLength(1);
+      expect(pendingFetches[0]?.body).toHaveLength(2); // A once, B once
+
+      pendingFetches[0]?.resolve(
+        new Response(JSON.stringify([{ data: { a: 1 } }, { data: { b: 2 } }]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      await delay(10);
+
+      expect(results.filter((r) => r.operation.key === opA.key)).toHaveLength(
+        2,
+      );
+    });
+  });
+
+  describe('When an operation with the same key is dispatched while a batched request is in flight', () => {
+    it('Then it coalesces onto the in-flight request instead of issuing a duplicate', async () => {
+      const opA = queryOperation(QueryA);
+      const opB = queryOperation(QueryB);
+
+      next(opA);
+      next(opB);
+      await delay(10);
+      expect(pendingFetches).toHaveLength(1);
+      expect(pendingFetches[0]?.body).toHaveLength(2);
+
+      // re-dispatch of A while the batch is in flight (e.g. urql-react
+      // re-subscribing from its effect after the render-phase teardown)
+      next(queryOperation(QueryA));
+      await delay(10);
+      expect(pendingFetches).toHaveLength(1);
+
+      pendingFetches[0]?.resolve(
+        new Response(JSON.stringify([{ data: { a: 1 } }, { data: { b: 2 } }]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      await delay(10);
+
+      // A's response fans out to both subscribers; B's to its one
+      expect(results.filter((r) => r.operation.key === opA.key)).toHaveLength(
+        2,
+      );
+      expect(results.filter((r) => r.operation.key === opB.key)).toHaveLength(
+        1,
+      );
+    });
+
+    it('Then it issues a fresh request once the in-flight response has been delivered', async () => {
+      next(queryOperation(QueryA));
+      next(queryOperation(QueryB));
+      await delay(10);
+      expect(pendingFetches).toHaveLength(1);
+
+      pendingFetches[0]?.resolve(
+        new Response(JSON.stringify([{ data: { a: 1 } }, { data: { b: 2 } }]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      await delay(10);
+
+      next(queryOperation(QueryA));
+      await delay(10);
+      expect(pendingFetches).toHaveLength(2);
+    });
+
+    it('Then it recovers and issues a fresh request after a network error', async () => {
+      const opA = queryOperation(QueryA);
+
+      next(opA);
+      next(queryOperation(QueryB));
+      await delay(10);
+      next(queryOperation(QueryA)); // coalesced onto the failing request
+      await delay(10);
+      expect(pendingFetches).toHaveLength(1);
+
+      pendingFetches[0]?.reject(new Error('connection reset'));
+      await delay(10);
+
+      const errored = results.filter((r) => r.operation.key === opA.key);
+      expect(errored).toHaveLength(2);
+      expect(errored[0]?.error?.networkError).toBeInstanceOf(Error);
+
+      next(queryOperation(QueryA));
+      await delay(10);
+      expect(pendingFetches).toHaveLength(2);
+    });
+  });
+
+  describe('When an operation with the same key is dispatched while a single-operation request is in flight', () => {
+    it('Then it coalesces onto the in-flight request and both subscribers receive the response', async () => {
+      const opA = queryOperation(QueryA);
+
+      next(opA);
+      await delay(10);
+      expect(pendingFetches).toHaveLength(1);
+
+      next(queryOperation(QueryA));
+      await delay(10);
+      expect(pendingFetches).toHaveLength(1);
+
+      pendingFetches[0]?.resolve(
+        new Response(JSON.stringify({ data: { a: 1 } }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+      await delay(10);
+
+      expect(results.filter((r) => r.operation.key === opA.key)).toHaveLength(
+        2,
+      );
+    });
+
+    it('Then it issues a fresh request after the in-flight request is torn down', async () => {
+      const opA = queryOperation(QueryA);
+
+      next(opA);
+      await delay(10);
+      expect(pendingFetches).toHaveLength(1);
+
+      // aborts the in-flight single request, which must release its key
+      next(teardownOperation(opA));
+      await delay(10);
+
+      next(queryOperation(QueryA));
+      await delay(10);
+      expect(pendingFetches).toHaveLength(2);
+    });
+  });
+});

--- a/packages/core/src/batching.ts
+++ b/packages/core/src/batching.ts
@@ -21,6 +21,7 @@ import {
   make,
   merge,
   mergeMap,
+  onEnd,
   pipe,
   type Source,
   share,
@@ -141,6 +142,9 @@ export type BatchFetchExchangeConfig = {
  * - Mutations and subscriptions are never batched
  * - Queries can opt-out of batching by setting `context.batch = false`
  * - Torn-down operations are automatically removed from pending batches
+ * - While a request for a given operation key is in flight, further operations
+ *   with the same key are coalesced onto it instead of issuing a duplicate
+ *   request — their subscribers receive the in-flight response when it lands
  */
 export function batchFetchExchange({
   batchInterval,
@@ -182,6 +186,20 @@ export function batchFetchExchange({
         Array<(result: OperationResult) => void>
       >();
 
+      // Keys of operations whose network request is currently in flight.
+      //
+      // urql's React bindings dispatch every query twice per hook mount (once
+      // during render to compute the initial state, once from the effect that
+      // subscribes for real) with a teardown in between. The teardown clears
+      // the Client's own dedup state, so both dispatches reach this exchange.
+      // Coalescing onto the in-flight request keeps that — and any other
+      // same-key overlap, such as several components mounting the same
+      // `cache-and-network` query — down to a single request; every
+      // subscriber's sink receives the shared response. Operations that must
+      // never be coalesced (post-transaction refreshes, poll ticks) already
+      // opt out of batching via `context.batch = false` and bypass this path.
+      const inFlight = new Set<number>();
+
       const batched$ = pipe(
         shared,
         filter(
@@ -192,7 +210,9 @@ export function batchFetchExchange({
             op.context.url === url,
             `Operation URL mismatch: expected "${url}", got "${op.context.url}"`,
           );
-          batcher.push(op);
+          if (!inFlight.has(op.key)) {
+            batcher.push(op);
+          }
           return make<OperationResult>(({ next }) => {
             const sinks = resultSinks.get(op.key);
 
@@ -227,17 +247,22 @@ export function batchFetchExchange({
 
         // Single operation → use standard fetch flow
         if (operations.length === 1) {
+          const operation = operations[0];
+          inFlight.add(operation.key);
           pipe(
-            makeSingleRequestSource(operations[0], ops$),
+            makeSingleRequestSource(operation, ops$),
             tap((result: OperationResult) => {
-              const sinks = resultSinks.get(operations[0].key);
+              const sinks = resultSinks.get(operation.key);
               if (sinks) {
                 for (const sink of sinks) {
                   sink(result);
                 }
-                resultSinks.delete(operations[0].key);
+                resultSinks.delete(operation.key);
               }
             }),
+            // Fires on completion and on teardown-triggered abort alike, so an
+            // aborted request can never leave its key stuck as in-flight.
+            onEnd(() => inFlight.delete(operation.key)),
             subscribe(() => {}), // Activate the source (Wonka sources are lazy)
           );
           return;
@@ -257,6 +282,10 @@ export function batchFetchExchange({
             ? fetchOptions()
             : fetchOptions || {};
 
+        for (const op of operations) {
+          inFlight.add(op.key);
+        }
+
         fetch(url, {
           ...opts,
           method: 'POST',
@@ -268,6 +297,9 @@ export function batchFetchExchange({
         })
           .then((res) => res.json() as Promise<ExecutionResult[]>)
           .then((results) => {
+            for (const op of operations) {
+              inFlight.delete(op.key);
+            }
             for (let i = 0; i < results.length && i < operations.length; i++) {
               const response = results[i];
               const op = operations[i];
@@ -296,6 +328,7 @@ export function batchFetchExchange({
           })
           .catch((err) => {
             for (const op of operations) {
+              inFlight.delete(op.key);
               const result: OperationResult = {
                 operation: op,
                 data: undefined,

--- a/packages/core/src/dedup.test.ts
+++ b/packages/core/src/dedup.test.ts
@@ -1,0 +1,153 @@
+import {
+  createRequest,
+  gql,
+  makeOperation,
+  type Operation,
+  type OperationContext,
+  type OperationResult,
+} from '@urql/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  makeSubject,
+  pipe,
+  type Source,
+  type Subscription,
+  subscribe,
+} from 'wonka';
+import { inFlightDedupExchange, refetching } from './dedup';
+
+const QueryA = gql`
+  query A {
+    a
+  }
+`;
+
+const MutationM = gql`
+  mutation M {
+    m
+  }
+`;
+
+function queryOperation(
+  extraContext: Partial<OperationContext> = {},
+): Operation {
+  return makeOperation('query', createRequest(QueryA, {}), {
+    url: 'https://api.test/graphql',
+    requestPolicy: 'cache-and-network',
+    ...extraContext,
+  } as OperationContext);
+}
+
+function resultFor(operation: Operation): OperationResult {
+  return {
+    operation,
+    data: { value: 42 },
+    error: undefined,
+    extensions: undefined,
+    stale: false,
+    hasNext: false,
+  };
+}
+
+describe(`Given the '${inFlightDedupExchange.name}' exchange`, () => {
+  let forwardedOps: Operation[];
+  let emitResult: (result: OperationResult) => void;
+  let next: (operation: Operation) => void;
+  let subscription: Subscription;
+
+  beforeEach(() => {
+    forwardedOps = [];
+
+    const opsSubject = makeSubject<Operation>();
+    const resultsSubject = makeSubject<OperationResult>();
+    next = opsSubject.next;
+    emitResult = resultsSubject.next;
+
+    const io = inFlightDedupExchange()({
+      forward: (ops$) => {
+        pipe(
+          ops$,
+          subscribe((op) => forwardedOps.push(op)),
+        );
+        return resultsSubject.source as Source<OperationResult>;
+      },
+      client: {} as never,
+      dispatchDebug: () => {},
+    });
+
+    subscription = pipe(
+      io(opsSubject.source),
+      subscribe(() => {}),
+    );
+  });
+
+  afterEach(() => {
+    subscription.unsubscribe();
+  });
+
+  describe('When a query is dispatched while the same key is in flight', () => {
+    it('Then it drops the duplicate', () => {
+      next(queryOperation());
+      next(queryOperation());
+
+      expect(forwardedOps).toHaveLength(1);
+    });
+
+    it('Then it forwards again once a result has arrived', () => {
+      const op = queryOperation();
+      next(op);
+      emitResult(resultFor(op));
+      next(queryOperation());
+
+      expect(forwardedOps).toHaveLength(2);
+    });
+
+    it('Then it forwards again after a teardown, which aborts the in-flight request', () => {
+      const op = queryOperation();
+      next(op);
+      next(makeOperation('teardown', op, op.context));
+      next(queryOperation());
+
+      expect(
+        forwardedOps.filter((forwarded) => forwarded.kind === 'query'),
+      ).toHaveLength(2);
+    });
+  });
+
+  describe('When a deliberate refresh is dispatched while the same key is in flight', () => {
+    it('Then it always forwards it', () => {
+      next(queryOperation());
+      next(queryOperation({ [refetching]: true } as never));
+
+      expect(forwardedOps).toHaveLength(2);
+    });
+
+    it('Then later duplicates coalesce onto the refresh', () => {
+      const op = queryOperation();
+      next(op);
+      emitResult(resultFor(op));
+
+      next(queryOperation({ [refetching]: true } as never));
+      next(queryOperation());
+
+      expect(forwardedOps).toHaveLength(2);
+    });
+  });
+
+  describe('When non-query operations are dispatched', () => {
+    it('Then it always forwards mutations and teardowns', () => {
+      const mutation = makeOperation('mutation', createRequest(MutationM, {}), {
+        url: 'https://api.test/graphql',
+        requestPolicy: 'network-only',
+      } as OperationContext);
+
+      next(mutation);
+      next(mutation);
+      const query = queryOperation();
+      next(query);
+      next(makeOperation('teardown', query, query.context));
+
+      expect(forwardedOps).toHaveLength(4);
+    });
+  });
+});

--- a/packages/core/src/dedup.ts
+++ b/packages/core/src/dedup.ts
@@ -1,0 +1,82 @@
+import type { Exchange, Operation, OperationResult } from '@urql/core';
+import { filter, pipe, tap } from 'wonka';
+
+/**
+ * Marks operations dispatched by the SDK's own refresh machinery (e.g.
+ * post-transaction refreshes), which must always reach the network: they exist
+ * to force fresh data, so serving them from an older in-flight request would
+ * defeat their purpose.
+ *
+ * @internal
+ */
+export const refetching = Symbol('refetching');
+
+/**
+ * A urql exchange that drops query operations whose key already has a network
+ * request in flight downstream, so concurrent subscribers to the same query
+ * share a single request. The surviving request's result is routed to every
+ * active subscriber by the urql `Client` (results are matched by operation
+ * key), so dropped duplicates still receive it.
+ *
+ * @remarks
+ * urql v4 removed its standalone `dedupExchange` in favour of dedup state kept
+ * on the `Client`, but that state is keyed to subscription liveness: it is
+ * cleared both by teardowns (which React bindings interleave into every hook
+ * mount) and by stale cached results under `cache-and-network`, letting
+ * same-key operations reach the network concurrently. This exchange restores
+ * deduplication keyed to what is actually in flight.
+ *
+ * - Only `query` operations are deduplicated; mutations, subscriptions and
+ *   teardowns always pass through
+ * - Operations marked with the {@link refetching} context symbol always pass
+ *   through, and start tracking their key so later duplicates coalesce onto
+ *   the fresher request
+ * - A teardown releases its key: the downstream `fetchExchange` aborts the
+ *   request on teardown, so no result would ever arrive to release it
+ *   otherwise
+ * - Intended for the non-batched pipeline. `batchFetchExchange` performs its
+ *   own coalescing instead, keyed to actual wire state — its batched requests
+ *   survive teardowns, so releasing keys on teardown would be wrong there
+ *
+ * @internal
+ */
+export function inFlightDedupExchange(): Exchange {
+  return ({ forward }) => {
+    const inFlight = new Set<number>();
+
+    return (ops$) => {
+      const forwarded$ = pipe(
+        ops$,
+        filter((operation: Operation) => {
+          if (operation.kind === 'teardown' || operation.kind === 'mutation') {
+            inFlight.delete(operation.key);
+            return true;
+          }
+
+          if (operation.kind !== 'query') {
+            return true;
+          }
+
+          if (
+            !(refetching in operation.context) &&
+            inFlight.has(operation.key)
+          ) {
+            return false;
+          }
+
+          inFlight.add(operation.key);
+          return true;
+        }),
+      );
+
+      return pipe(
+        forward(forwarded$),
+        tap((result: OperationResult) => {
+          if (!result.hasNext) {
+            inFlight.delete(result.operation.key);
+          }
+        }),
+      );
+    };
+  };
+}


### PR DESCRIPTION
## Problem

The same query (identical `operation.key`) fires multiple concurrent HTTP requests. Measured in the Aave Pro interface: `Reserves` (a ~5 MB response) was fetched 2× on cold load and 3–4× per warm navigation.

Root cause chain, each link verified against source:

1. urql's React bindings dispatch every query **twice per hook mount** — once during render to compute the initial state (immediately unsubscribed), once from the effect that subscribes for real — with a teardown in between.
2. That teardown clears the urql `Client`'s own dedup state (`dispatched`), so both dispatches pass it. Under `cache-and-network`, stale cached results clear it too, so every newly mounting subscriber on a warm cache re-fires as well.
3. Vanilla urql absorbs this because `fetchExchange` aborts on teardown. Our `batchFetchExchange`'s multi-op path is a raw `fetch()` with no teardown handling, so **both dispatches complete as full round trips**.

urql v4 removed the standalone `dedupExchange`, and re-adding it wouldn't help: it also releases keys on teardown (verified in the v3 source), which is exactly the state the mount cycle wipes.

## Fix

In-flight coalescing keyed to actual wire state:

- **`batchFetchExchange`**: an `inFlight` key set. While a request for a key is out, same-key operations skip the queue but still register their result sink — the shared response fans out to every subscriber (result routing is by key). Multi-op keys clear on delivery/error; single-op keys clear on source end, so a teardown-triggered abort can never strand a key.
- **`inFlightDedupExchange`** (new): the non-batched pipeline (`batch: false` clients) previously had no coalescing at all. This exchange drops duplicate queries while their key is in flight, releases on teardown (correct there — `fetchExchange` aborts, so no result would ever release it), and always forwards operations marked with the `refetching` symbol so post-transaction refreshes are never served by an older in-flight request.

Operations that must never be coalesced — post-transaction refreshes, poll ticks, mutations — already use `batch: false` and are exempt by construction on the batched pipeline, and by the `refetching` marker on the non-batched one.

Measured in the interface app with the patched exchange: `Reserves` per navigation went 2→1 (cold), 4→1 and 3→1 (warm).

## Tests

12 new tests (6 batching, 6 dedup); core suite 25/25. The client/react suite failures and the `AaveClient.ts` DTS error reproduce on a clean `main` checkout (missing `.env` chain id / pre-existing type error) and are unrelated.

## Known limitation / follow-up

If a multi-op batched `fetch()` never settles, its keys stay in flight until the runtime times it out; new subscribers wait on it rather than retrying independently. A bounded timeout on that fetch would close this.
