### PR TITLE
fix: select __typename on netApyBreakdown

### DIFF
--- a/packages/graphql/src/fragments/user.ts
+++ b/packages/graphql/src/fragments/user.ts
@@ -83,6 +83,7 @@ export const UserSummaryFragment = graphql(
       ...PercentNumber
     }
     netApyBreakdown {
+      __typename
       base {
         ...PercentNumber
       }
@@ -184,6 +185,7 @@ export const UserPositionFragment = graphql(
       ...PercentNumberWithChange
     }
     netApyBreakdown {
+      __typename
       base {
         ...PercentNumber
       }

--- a/packages/graphql/src/testing.ts
+++ b/packages/graphql/src/testing.ts
@@ -384,6 +384,7 @@ export function makeUserPosition({
     netSupplyApy: makePercentNumberWithChange(0),
     netBorrowApy: makePercentNumberWithChange(0),
     netApyBreakdown: {
+      __typename: 'NetApyBreakdown',
       base: makePercentNumber(0),
       rewards: makePercentNumber(0),
       underlying: makePercentNumber(0),


### PR DESCRIPTION
## What

Selects `__typename` on the `netApyBreakdown` field in `UserSummaryFragment` and `UserPositionFragment`, and sets it on the `makeUserPosition` test fixture.

## Why

Three tests fail on `underlying-apy` with `InvariantError: Expected result to be Ok: undefined`:

- `useBorrow` / `useSupply` / `useSetUserSuppliesAsCollateral`, "flag the cache entry as stale for the next activation"

The stack points at the `beforeEach`, not the test body: `assertOk(primed)` on the msw-mocked `UserPositions` query that primes the cache. `netApyBreakdown` was added to the fragment as an inline selection without `__typename`, unlike every other type in `fragments/`, so the generated type had no `__typename` and the fixture could not set one. `NetApyBreakdown` is registered in `cache.ts` as an embedded value, so graphcache could not write the object, the cached read came back incomplete, and `GqlClient` saw neither data nor an error - hence the empty message.

Real responses were unaffected: urql injects `__typename` into every selection set at the exchange level. Only the hand-written fixture, typed off the raw document, was missing it.

No changeset: this fixes an unreleased change on the base branch, so the changelog entry there already covers it.

## Verification

`pnpm check:graphql` and `pnpm build` pass (the build failed before the fragment change, with `TS2353: '__typename' does not exist in type ...` on the fixture). All three tests get past the cache-priming `beforeEach`; they then fail locally at the on-chain send with `insufficient funds for gas * price + value`, which is my Tenderly fork wallet, not CI's.
